### PR TITLE
Add clear highlight button to note detect analysis

### DIFF
--- a/app/components/NoteDetector/NoteDetector.tsx
+++ b/app/components/NoteDetector/NoteDetector.tsx
@@ -158,7 +158,8 @@ function NoteDetectorUI({ detection }: NoteDetectorUIProps) {
 
   const { matchingKeys, matchingChords } = useMatchingKeysAndChords(noteLog);
   const { setKeyScale } = useScaleKey();
-  const { setChordHighlight } = useHighlight();
+  const { setChordHighlight, clearChordHighlight, chordHighlightNotes } =
+    useHighlight();
 
   return (
     <div className="w-full max-w-2xl space-y-4">
@@ -284,9 +285,21 @@ function NoteDetectorUI({ detection }: NoteDetectorUIProps) {
       {/* Key / Chord analysis */}
       <div className="space-y-2">
         <div className="flex items-center justify-between">
-          <h3 className="text-sm font-medium text-foreground">
-            Analysis
-          </h3>
+          <div className="flex items-center gap-2">
+            <h3 className="text-sm font-medium text-foreground">
+              Analysis
+            </h3>
+            {chordHighlightNotes.length > 0 && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-6 text-xs"
+                onClick={clearChordHighlight}
+              >
+                Clear highlight
+              </Button>
+            )}
+          </div>
           <SegmentedToggle
             value={analysisMode}
             onChange={(v) => setAnalysisMode(v as 'keys' | 'chords')}


### PR DESCRIPTION
## Summary

- When clicking a chord in the Note Detect analysis section, it highlights those notes on the fretboard (existing behavior). Now a "Clear highlight" button appears next to the Analysis heading so users can return to the default fretboard view, matching the same UX pattern from ChordExplorer.

## Test plan

- [ ] Click a chord in Note Detect analysis -> fretboard highlights -> "Clear highlight" button appears
- [ ] Click "Clear highlight" -> fretboard returns to normal scale view, button disappears
- [ ] Button does not appear when no chord highlight is active

Made with [Cursor](https://cursor.com)