### PR TITLE
Live guitar-neck overlay prototype (Python)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+fretboard_cam/testdata/**/*.mp4 filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,13 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 *storybook.log
+
+# python (fretboard_cam)
+__pycache__/
+*.py[cod]
+.venv/
+*.pt
+*.onnx
+fretboard_cam/output/
+fretboard_cam/.pytest_cache/
+fretboard_cam/*.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,6 @@ __pycache__/
 *.pt
 *.onnx
 fretboard_cam/output/
+fretboard_cam/recordings/
 fretboard_cam/.pytest_cache/
 fretboard_cam/*.egg-info/

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ npm run format     # prettier
 Changes merged to main will auto-deploy to vercel
 
 
+## Next: live fretboard overlay
+
+The next version of this project is a local camera overlay on a real guitar neck, plus a modular dashboard later. See [ROADMAP.md](./ROADMAP.md) and the standalone Python prototype in [`fretboard_cam/`](./fretboard_cam).
+
 ## About
 
 See the [.cursorrules](./.cursorrules) file for an in-depth description of where to find things and how they're built

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,112 @@
+# Jam Dashboard roadmap
+
+Jam Dashboard started as a web fretboard visualizer, ear trainer, and chord explorer. The next version is a **local, modular practice dashboard** whose primary UI is a live camera overlay locked to a real guitar neck. The current Remix app remains useful as a 2D reference view and as a source of music-theory behavior, but camera + hardware work will live in Python so we can use the user's webcam, mic, and GPU.
+
+This file is the long-term plan. We are building it in short iterations. **The current iteration is only the live fretboard overlay.**
+
+## North star
+
+A desktop dashboard that:
+
+- Shows a camera feed of the player's guitar with a perspective-correct overlay on the neck
+- Offers several visualization modes (full scale, pentatonic, chord tones, CAGED shapes, arbitrary custom cells)
+- Can also show the existing 2D fretboard, chord grid, and other panels as modules around the camera
+- Lets the player trigger actions that change what is drawn (key, scale, chord, overlay style)
+- Later, drives those same actions with voice and an AI agent that has tools
+
+Think of the reference recording: camera in the center, HUD around it, a flat neck diagram, mode toggles, and overlays that mean "play these cells." Our first slice is the hard part of that picture — **detect the neck and stick markers to it.**
+
+## Iteration 1 — Live fretboard overlay (current)
+
+**Goal:** Prove we can find a guitar neck in video and paint *something* on it.
+
+In scope:
+
+- Python app that reads a webcam or video file
+- Detect the neck without training a custom model (YOLO-World / COCO YOLO + geometry)
+- Track the neck as it moves
+- Overlay a grid and numbered markers on arbitrary `(string, fret)` cells
+- Manual four-corner fallback if auto-detect fails (`--corners`, same idea as `capture-ref`)
+
+Out of scope for this iteration:
+
+- Real scales, chords, or the existing TypeScript theory code
+- Voice / AI agent
+- Hand tracking
+- The modular dashboard chrome
+- Training our own detector
+
+Code: [`fretboard_cam/`](./fretboard_cam).
+
+### Do we need to train a model?
+
+Not for this demo. YOLO-World is an open-vocabulary detector we prompt with `"guitar neck"` / `"guitar fretboard"`. If that is too loose on real practice-cam footage, options in order:
+
+1. Keep using `--corners` / a one-time click calibration and optical flow (already implemented)
+2. Try COCO YOLO's `guitar` class and tighten the quad with line detection
+3. Only then collect a small labeled set and fine-tune YOLO-OBB on fretboards
+
+If we do get to (3), we will need a short video of *your* guitar from the camera angle you actually practice with. A downloaded YouTube clip is enough to develop against; your own clip is what we would train on.
+
+## Iteration 2 — Overlay that means something
+
+Reuse the music-theory ideas from the current web app, reimplemented in Python (or called via a small shared layer):
+
+- Key / scale picker drives which cells light up
+- Modes: all scale tones, pentatonic only, chord tones, CAGED box
+- Colors matched to the existing note-color language
+- HUD label on the neck (`G mixolydian`, `D pentatonic`, etc.)
+
+The web 2D fretboard can stay as a second view of the same state.
+
+## Iteration 3 — Modular dashboard
+
+A local UI (likely still Python for the camera process, with a webview or a thin desktop shell) that can show several panels:
+
+- Live overlay (primary)
+- Flat 24-fret diagram (as in the reference recording)
+- Chord list / voicing panel
+- Settings: tuning, visible frets, overlay alpha, lefty, number of strings
+
+Panels are modules. Visualization config is a single state object that any panel or action can change.
+
+## Iteration 4 — Actions, then voice + AI
+
+Treat overlay changes as **tools**, not one-off UI handlers:
+
+- `set_key_scale(key, scale)`
+- `set_mode(scale|pentatonic|chord|caged|custom)`
+- `highlight_chord(name)`
+- `set_visible_frets(n)` / `set_alpha(x)`
+- `clear_overlay()`
+
+Keyboard and GUI fire those tools first. Then an AI agent (mic → speech-to-text → LLM with tool calls) can say "show me the G minor pentatonic box" and hit the same tools. Voice is a later layer; it should not be baked into the renderer.
+
+## Later
+
+- Hand / fingertip tracking (`M hands` in the reference HUD)
+- Pitch detection from the local audio interface, driving a "you are here" marker (we already have a web pitch detector to learn from)
+- Ghost / tablature scrolling along the neck
+- Export of takes
+- Optional cloud sync; default remains on-device
+
+## What stays from the current repo
+
+Keep, and eventually share as libraries / mirrored Python ports:
+
+- Fretboard layout and coloring rules
+- Scale / chord theory (`tonal`-style helpers, CAGED)
+- Ear trainer and chord explorer as dashboard modules
+
+Do not force the camera pipeline through Remix. Local hardware (camera, mic, GPU) is a Python process.
+
+## Suggested repo shape over time
+
+```
+jam-dashboard/
+  app/                 # existing Remix web tool
+  fretboard_cam/       # iteration 1 camera overlay (this work)
+  ROADMAP.md
+```
+
+Later we may split `fretboard_cam` into `detect/`, `overlay/`, `dashboard/`, and `agent/` packages. Not yet.

--- a/fretboard_cam/.gitignore
+++ b/fretboard_cam/.gitignore
@@ -1,0 +1,13 @@
+# fretboard_cam
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+*.pt
+*.onnx
+output/
+runs/
+.pytest_cache/
+*.egg-info/
+dist/
+build/

--- a/fretboard_cam/.gitignore
+++ b/fretboard_cam/.gitignore
@@ -7,6 +7,7 @@ venv/
 *.onnx
 output/
 runs/
+recordings/
 .pytest_cache/
 *.egg-info/
 dist/

--- a/fretboard_cam/README.md
+++ b/fretboard_cam/README.md
@@ -75,7 +75,15 @@ cd fretboard_cam
 python -m pytest -q
 ```
 
-Tests cover fret math, corner ordering, overlay painting, contour detection on a synthetic neck, and optical-flow tracking. They do not download YOLO weights.
+Tests cover fret math, corner ordering, overlay painting, contour detection on a synthetic neck, optical-flow tracking, and neck isolation from a guitar-shaped mask. They do not download YOLO weights.
+
+This prototype was run on:
+
+- A moving synthetic neck (contour lock, numbered cells stay on the board)
+- A public PLOS ONE electric-guitar clip (YOLO-World `guitar` + parallel string lines, lock held for the processed take)
+- The Drive demo recording you shared (same pipeline; that clip already has a dense HUD, so a clean practice-cam take will be a better lock)
+
+`--corners` is the escape hatch if auto-detect is off on your guitar/camera.
 
 ## Layout
 

--- a/fretboard_cam/README.md
+++ b/fretboard_cam/README.md
@@ -31,11 +31,21 @@ On a machine with a display, install `opencv-python` instead of `opencv-python-h
 
 ## Run
 
-Webcam (local machine):
+Webcam (local machine, live window):
 
 ```bash
-python -m fretboard_cam --source 0 --detector yolo-world --output overlay.mp4
+python -m fretboard_cam --source 0 --detector yolo-world --debug
 ```
+
+A window opens. Point the camera at a guitar neck.
+
+- Click **REC** (top right) or press **R** to start/stop recording
+- Each take writes `recordings/<timestamp>/raw.mp4` (no overlay) and `overlay.mp4` (with overlay)
+- Press **Q** to quit
+
+On a Mac, grant camera access to Terminal (or Cursor) if macOS asks.
+
+`--no-preview` skips the window (useful for file-only processing). `--output overlay.mp4` also records the overlay stream from the CLI.
 
 Video file:
 

--- a/fretboard_cam/README.md
+++ b/fretboard_cam/README.md
@@ -8,8 +8,8 @@ This is intentionally *not* wired into the existing Remix/TypeScript app. The ov
 
 We avoided training a CNN for this pass. The pipeline is:
 
-1. **Detect a neck box** with a pretrained open-vocabulary model ([YOLO-World](https://docs.ultralytics.com/models/yolo-world/)), prompted with `guitar neck` / `guitar fretboard` / `guitar`. COCO YOLOv8 (`guitar` class) is a fallback. Neither requires labeling data.
-2. **Turn the box into a quad** with GrabCut + a min-area rectangle / polygon approximation. That gives four corners: nut-bass, body-bass, body-treble, nut-treble.
+1. **Detect a guitar box** with a pretrained open-vocabulary model ([YOLO-World](https://docs.ultralytics.com/models/yolo-world/)), prompted with `guitar neck` / `guitar fretboard` / `guitar`. COCO YOLOv8 (`guitar` class) is a fallback. Neither requires labeling data.
+2. **Turn the box into a neck quad** by clustering parallel string/neck-edge lines, then keeping the bundle whose *interior is maple-bright* (not the dark pickguard) and whose width looks like a neck. The longest maple run along that band is the fretboard; it stops where the wood hits the pickguard or a lamp flare. Fallbacks: GrabCut + a thin-region profile, then `--corners`.
 3. **Track** those corners with Lucas-Kanade optical flow and a light blend so the overlay does not jump every frame.
 4. **Overlay** a perspective-correct grid. Fret spacing uses the standard 12-TET formula `1 - 2^(-n/12)`. Highlighted cells are hardcoded fret numbers.
 
@@ -91,7 +91,7 @@ This prototype was run on:
 
 - A moving synthetic neck (contour lock, numbered cells stay on the board)
 - A public PLOS ONE electric-guitar clip (YOLO-World `guitar` + parallel string lines, lock held for the processed take)
-- The Drive demo recording you shared (same pipeline; that clip already has a dense HUD, so a clean practice-cam take will be a better lock)
+- The author's FaceTime Telecaster clip in `testdata/chase-tele-20260812/` (maple neck vs black pickguard; the fitter now scores light-wood interiors so it does not treat pickguard strings as the fretboard)
 
 `--corners` is the escape hatch if auto-detect is off on your guitar/camera.
 

--- a/fretboard_cam/README.md
+++ b/fretboard_cam/README.md
@@ -1,0 +1,90 @@
+# fretboard_cam
+
+Standalone Python prototype for the first demo of Jam Dashboard's next version: **lock a grid of numbered markers onto a guitar neck in a camera/video feed**.
+
+This is intentionally *not* wired into the existing Remix/TypeScript app. The overlay only needs to prove we can find a fretboard and paint something on it. Markers are arbitrary `(string, fret)` cells — not a real scale.
+
+## Approach (no custom training)
+
+We avoided training a CNN for this pass. The pipeline is:
+
+1. **Detect a neck box** with a pretrained open-vocabulary model ([YOLO-World](https://docs.ultralytics.com/models/yolo-world/)), prompted with `guitar neck` / `guitar fretboard` / `guitar`. COCO YOLOv8 (`guitar` class) is a fallback. Neither requires labeling data.
+2. **Turn the box into a quad** with GrabCut + a min-area rectangle / polygon approximation. That gives four corners: nut-bass, body-bass, body-treble, nut-treble.
+3. **Track** those corners with Lucas-Kanade optical flow and a light blend so the overlay does not jump every frame.
+4. **Overlay** a perspective-correct grid. Fret spacing uses the standard 12-TET formula `1 - 2^(-n/12)`. Highlighted cells are hardcoded fret numbers.
+
+If auto-detect is wrong on a given guitar/camera, pass `--corners` once (the same idea as `capture-ref` in the reference recording) and the tracker will carry the quad forward.
+
+**When we would train:** if YOLO-World cannot lock onto *your* guitar from a typical practice-cam angle, the next step is a small YOLO-OBB dataset of fretboards (a few hundred frames), not a from-scratch CNN. Manual `--corners` is enough to keep iterating until then.
+
+## Setup
+
+```bash
+cd fretboard_cam
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt          # geometry, overlay, tests
+pip install -r requirements-ml.txt       # YOLO-World / COCO YOLO
+```
+
+On a machine with a display, install `opencv-python` instead of `opencv-python-headless` if you want a live preview window later.
+
+## Run
+
+Webcam (local machine):
+
+```bash
+python -m fretboard_cam --source 0 --detector yolo-world --output overlay.mp4
+```
+
+Video file:
+
+```bash
+python -m fretboard_cam \
+  --source path/to/guitar.mp4 \
+  --detector yolo-world \
+  --visible-frets 12 \
+  --highlights 6:3,6:5,5:3,5:5,4:2,4:4,1:3,1:5 \
+  --output output/overlay.mp4 \
+  --save-frames-dir output/frames \
+  --debug
+```
+
+Known quad, no neural net:
+
+```bash
+python -m fretboard_cam \
+  --source path/to/guitar.mp4 \
+  --detector manual \
+  --corners 120,360,820,390,800,230,150,250 \
+  --output output/overlay.mp4
+```
+
+High-contrast / synthetic necks:
+
+```bash
+python -m fretboard_cam --source synthetic.mp4 --detector contour --output overlay.mp4
+```
+
+`--highlights` is `string:fret` with string 1 = high E and string 6 = low E.
+
+## Tests
+
+```bash
+cd fretboard_cam
+python -m pytest -q
+```
+
+Tests cover fret math, corner ordering, overlay painting, contour detection on a synthetic neck, and optical-flow tracking. They do not download YOLO weights.
+
+## Layout
+
+```
+fretboard_cam/
+  geometry.py   # fret spacing, homography, corner order
+  overlay.py    # translucent cells + numbered dots
+  detect.py     # yolo-world / yolo-coco / contour / manual
+  track.py      # optical flow + blending
+  app.py        # CLI
+  synthetic.py  # fake neck for tests
+```

--- a/fretboard_cam/fretboard_cam/__init__.py
+++ b/fretboard_cam/fretboard_cam/__init__.py
@@ -1,0 +1,13 @@
+"""Live guitar-neck overlay for Jam Dashboard."""
+
+from .app import main
+from .geometry import order_fretboard_corners, project_cell
+from .overlay import OverlayConfig, draw_fretboard_overlay
+
+__all__ = [
+    "main",
+    "OverlayConfig",
+    "draw_fretboard_overlay",
+    "order_fretboard_corners",
+    "project_cell",
+]

--- a/fretboard_cam/fretboard_cam/__main__.py
+++ b/fretboard_cam/fretboard_cam/__main__.py
@@ -1,0 +1,4 @@
+from .app import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/fretboard_cam/fretboard_cam/app.py
+++ b/fretboard_cam/fretboard_cam/app.py
@@ -1,0 +1,223 @@
+"""CLI for live/video fretboard overlay."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from .detect import Detector, build_detector
+from .overlay import DEFAULT_HIGHLIGHTS, OverlayConfig, draw_fretboard_overlay, draw_hud
+from .track import QuadTracker
+
+
+def parse_corners(raw: str) -> np.ndarray:
+    values = [float(part.strip()) for part in raw.replace(" ", ",").split(",") if part.strip()]
+    if len(values) != 8:
+        raise argparse.ArgumentTypeError(
+            "corners must be 8 numbers: nut_bass_x,nut_bass_y,body_bass_x,body_bass_y,"
+            "body_treble_x,body_treble_y,nut_treble_x,nut_treble_y"
+        )
+    return np.array(values, dtype=np.float32).reshape(4, 2)
+
+
+def parse_highlights(raw: str) -> list[tuple[int, int]]:
+    cells: list[tuple[int, int]] = []
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        string_s, fret_s = part.split(":")
+        cells.append((int(string_s), int(fret_s)))
+    if not cells:
+        raise argparse.ArgumentTypeError("highlights must look like 6:3,5:5,1:3")
+    return cells
+
+
+def open_source(source: str) -> cv2.VideoCapture:
+    if source.isdigit():
+        cap = cv2.VideoCapture(int(source))
+    else:
+        cap = cv2.VideoCapture(source)
+    if not cap.isOpened():
+        raise SystemExit(f"could not open source: {source}")
+    return cap
+
+
+def make_writer(
+    path: str,
+    width: int,
+    height: int,
+    fps: float,
+) -> cv2.VideoWriter:
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    writer = cv2.VideoWriter(path, fourcc, max(fps, 1.0), (width, height))
+    if not writer.isOpened():
+        raise SystemExit(f"could not open video writer: {path}")
+    return writer
+
+
+def process_stream(
+    cap: cv2.VideoCapture,
+    detector: Detector,
+    *,
+    overlay_config: OverlayConfig,
+    detect_every: int,
+    max_frames: int,
+    output_path: str | None,
+    save_frames_dir: str | None,
+    save_frame_every: int,
+    debug: bool,
+) -> int:
+    fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH) or 0)
+    height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT) or 0)
+    writer = None
+    tracker = QuadTracker()
+    processed = 0
+    last_conf: float | None = None
+    last_label = detector.name
+
+    if save_frames_dir:
+        Path(save_frames_dir).mkdir(parents=True, exist_ok=True)
+
+    while True:
+        ok, frame = cap.read()
+        if not ok:
+            break
+        if width == 0 or height == 0:
+            height, width = frame.shape[:2]
+        if writer is None and output_path:
+            writer = make_writer(output_path, width, height, fps)
+
+        should_detect = processed % max(1, detect_every) == 0 or not tracker.locked
+        detection = detector.detect(frame) if should_detect else None
+        detected_corners = None if detection is None else detection.corners
+        if detection is not None:
+            last_conf = detection.confidence
+            last_label = detection.label
+
+        corners = tracker.update(frame, detected_corners)
+        if corners is not None:
+            vis = draw_fretboard_overlay(frame, corners, overlay_config)
+        else:
+            vis = frame.copy()
+        vis = draw_hud(
+            vis,
+            detector=f"{detector.name}/{last_label}",
+            tracked=corners is not None,
+            confidence=last_conf,
+            extra_lines=[
+                f"frame {processed}",
+                f"frets {overlay_config.visible_frets}  alpha {overlay_config.alpha:.2f}",
+            ],
+        )
+        if debug and detection is not None and detection.box_xyxy is not None:
+            x1, y1, x2, y2 = [int(round(v)) for v in detection.box_xyxy]
+            cv2.rectangle(vis, (x1, y1), (x2, y2), (0, 255, 255), 2)
+
+        if writer is not None:
+            writer.write(vis)
+        if (
+            save_frames_dir
+            and processed % max(1, save_frame_every) == 0
+        ):
+            cv2.imwrite(
+                os.path.join(save_frames_dir, f"overlay_{processed:05d}.jpg"),
+                vis,
+                [int(cv2.IMWRITE_JPEG_QUALITY), 92],
+            )
+
+        processed += 1
+        if max_frames and processed >= max_frames:
+            break
+        if processed % 30 == 0:
+            print(f"processed {processed} frames, lock={tracker.locked}", flush=True)
+
+    cap.release()
+    if writer is not None:
+        writer.release()
+    return processed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Overlay numbered fret markers on a detected guitar neck."
+    )
+    parser.add_argument(
+        "--source",
+        default="0",
+        help="Webcam index, video path, or image path.",
+    )
+    parser.add_argument("--output", default=None, help="Optional mp4 output path.")
+    parser.add_argument(
+        "--detector",
+        default="yolo-world",
+        choices=["yolo-world", "yolo-coco", "contour", "manual"],
+        help="yolo-world uses open-vocabulary prompts (no training). "
+        "manual requires --corners. contour is for high-contrast / synthetic necks.",
+    )
+    parser.add_argument(
+        "--corners",
+        type=parse_corners,
+        default=None,
+        help="Eight numbers for a manual quad (nut_bass, body_bass, body_treble, nut_treble).",
+    )
+    parser.add_argument("--visible-frets", type=int, default=12)
+    parser.add_argument("--alpha", type=float, default=0.42)
+    parser.add_argument(
+        "--highlights",
+        type=parse_highlights,
+        default=None,
+        help="Comma-separated string:fret cells, e.g. 6:3,5:5,1:3",
+    )
+    parser.add_argument("--detect-every", type=int, default=8)
+    parser.add_argument("--max-frames", type=int, default=0)
+    parser.add_argument("--save-frames-dir", default=None)
+    parser.add_argument("--save-frame-every", type=int, default=30)
+    parser.add_argument("--no-grid", action="store_true")
+    parser.add_argument("--debug", action="store_true")
+    parser.add_argument(
+        "--label",
+        default="DEMO  numbered frets",
+        help="HUD label drawn on the overlay.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.detector == "manual" and args.corners is None:
+        raise SystemExit("manual detector requires --corners")
+
+    detector = build_detector(args.detector, corners=args.corners)
+    config = OverlayConfig(
+        visible_frets=args.visible_frets,
+        alpha=args.alpha,
+        highlights=args.highlights or DEFAULT_HIGHLIGHTS,
+        draw_grid=not args.no_grid,
+        label=args.label,
+    )
+    cap = open_source(args.source)
+    processed = process_stream(
+        cap,
+        detector,
+        overlay_config=config,
+        detect_every=args.detect_every,
+        max_frames=args.max_frames,
+        output_path=args.output,
+        save_frames_dir=args.save_frames_dir,
+        save_frame_every=args.save_frame_every,
+        debug=args.debug,
+    )
+    print(f"done, {processed} frames")
+    return 0 if processed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/fretboard_cam/fretboard_cam/app.py
+++ b/fretboard_cam/fretboard_cam/app.py
@@ -214,8 +214,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--detector",
         default="yolo-world",
-        choices=["yolo-world", "yolo-coco", "contour", "manual"],
+        choices=["yolo-world", "yolo-coco", "contour", "ridge", "manual"],
         help="yolo-world uses open-vocabulary prompts (no training). "
+        "ridge fits a maple neck on a dark shirt. "
         "manual requires --corners. contour is for high-contrast / synthetic necks.",
     )
     parser.add_argument(

--- a/fretboard_cam/fretboard_cam/app.py
+++ b/fretboard_cam/fretboard_cam/app.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+import time
+from collections import deque
 from pathlib import Path
 
 import cv2
@@ -12,7 +14,10 @@ import numpy as np
 
 from .detect import Detector, build_detector
 from .overlay import DEFAULT_HIGHLIGHTS, OverlayConfig, draw_fretboard_overlay, draw_hud
+from .record import SessionRecorder, draw_record_button, point_in_rect
 from .track import QuadTracker
+
+WINDOW_NAME = "Jam Dashboard — fretboard overlay"
 
 
 def parse_corners(raw: str) -> np.ndarray:
@@ -40,7 +45,13 @@ def parse_highlights(raw: str) -> list[tuple[int, int]]:
 
 def open_source(source: str) -> cv2.VideoCapture:
     if source.isdigit():
-        cap = cv2.VideoCapture(int(source))
+        index = int(source)
+        cap = cv2.VideoCapture(index, cv2.CAP_AVFOUNDATION)
+        if not cap.isOpened():
+            cap = cv2.VideoCapture(index)
+        cap.set(cv2.CAP_PROP_FRAME_WIDTH, 1280)
+        cap.set(cv2.CAP_PROP_FRAME_HEIGHT, 720)
+        cap.set(cv2.CAP_PROP_FPS, 30)
     else:
         cap = cv2.VideoCapture(source)
     if not cap.isOpened():
@@ -54,12 +65,9 @@ def make_writer(
     height: int,
     fps: float,
 ) -> cv2.VideoWriter:
-    Path(path).parent.mkdir(parents=True, exist_ok=True)
-    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
-    writer = cv2.VideoWriter(path, fourcc, max(fps, 1.0), (width, height))
-    if not writer.isOpened():
-        raise SystemExit(f"could not open video writer: {path}")
-    return writer
+    from .record import make_writer as _make_writer
+
+    return _make_writer(Path(path), width, height, fps)
 
 
 def process_stream(
@@ -73,75 +81,123 @@ def process_stream(
     save_frames_dir: str | None,
     save_frame_every: int,
     debug: bool,
+    preview: bool,
 ) -> int:
     fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
     width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH) or 0)
     height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT) or 0)
     writer = None
     tracker = QuadTracker()
+    recorder = SessionRecorder()
     processed = 0
     last_conf: float | None = None
     last_label = detector.name
+    frame_times: deque[float] = deque(maxlen=30)
+    last_tick = time.perf_counter()
+    live_fps = 0.0
+    button_rect = (0, 0, 0, 0)
+    ui = {"click": None}
 
     if save_frames_dir:
         Path(save_frames_dir).mkdir(parents=True, exist_ok=True)
 
-    while True:
-        ok, frame = cap.read()
-        if not ok:
-            break
-        if width == 0 or height == 0:
-            height, width = frame.shape[:2]
-        if writer is None and output_path:
-            writer = make_writer(output_path, width, height, fps)
+    if preview:
+        cv2.namedWindow(WINDOW_NAME, cv2.WINDOW_NORMAL)
 
-        should_detect = processed % max(1, detect_every) == 0 or not tracker.locked
-        detection = detector.detect(frame) if should_detect else None
-        detected_corners = None if detection is None else detection.corners
-        if detection is not None:
-            last_conf = detection.confidence
-            last_label = detection.label
+        def _on_mouse(event: int, x: int, y: int, _flags: int, _param: object) -> None:
+            if event == cv2.EVENT_LBUTTONDOWN:
+                ui["click"] = (x, y)
 
-        corners = tracker.update(frame, detected_corners)
-        if corners is not None:
-            vis = draw_fretboard_overlay(frame, corners, overlay_config)
-        else:
-            vis = frame.copy()
-        vis = draw_hud(
-            vis,
-            detector=f"{detector.name}/{last_label}",
-            tracked=corners is not None,
-            confidence=last_conf,
-            extra_lines=[
-                f"frame {processed}",
-                f"frets {overlay_config.visible_frets}  alpha {overlay_config.alpha:.2f}",
-            ],
-        )
-        if debug and detection is not None and detection.box_xyxy is not None:
-            x1, y1, x2, y2 = [int(round(v)) for v in detection.box_xyxy]
-            cv2.rectangle(vis, (x1, y1), (x2, y2), (0, 255, 255), 2)
+        cv2.setMouseCallback(WINDOW_NAME, _on_mouse)
 
-        if writer is not None:
-            writer.write(vis)
-        if (
-            save_frames_dir
-            and processed % max(1, save_frame_every) == 0
-        ):
-            cv2.imwrite(
-                os.path.join(save_frames_dir, f"overlay_{processed:05d}.jpg"),
+    try:
+        while True:
+            ok, frame = cap.read()
+            if not ok:
+                break
+            if width == 0 or height == 0:
+                height, width = frame.shape[:2]
+            if writer is None and output_path:
+                writer = make_writer(output_path, width, height, fps)
+
+            now = time.perf_counter()
+            frame_times.append(now - last_tick)
+            last_tick = now
+            if frame_times:
+                live_fps = 1.0 / max(sum(frame_times) / len(frame_times), 1e-3)
+
+            searching = not tracker.locked
+            interval = 3 if searching else max(1, detect_every)
+            should_detect = processed % interval == 0
+            detection = detector.detect(frame) if should_detect else None
+            detected_corners = None if detection is None else detection.corners
+            if detection is not None:
+                last_conf = detection.confidence
+                last_label = detection.label
+
+            corners = tracker.update(frame, detected_corners)
+            if corners is not None:
+                vis = draw_fretboard_overlay(frame, corners, overlay_config)
+            else:
+                vis = frame.copy()
+            vis = draw_hud(
                 vis,
-                [int(cv2.IMWRITE_JPEG_QUALITY), 92],
+                detector=f"{detector.name}/{last_label}",
+                tracked=corners is not None,
+                confidence=last_conf,
+                extra_lines=[
+                    f"frame {processed}  {live_fps:.1f} fps",
+                    f"frets {overlay_config.visible_frets}  alpha {overlay_config.alpha:.2f}",
+                    "click REC or press R   Q quit",
+                ],
             )
+            if debug and detection is not None and detection.box_xyxy is not None:
+                x1, y1, x2, y2 = [int(round(v)) for v in detection.box_xyxy]
+                cv2.rectangle(vis, (x1, y1), (x2, y2), (0, 255, 255), 2)
 
-        processed += 1
-        if max_frames and processed >= max_frames:
-            break
-        if processed % 30 == 0:
-            print(f"processed {processed} frames, lock={tracker.locked}", flush=True)
+            button_rect = draw_record_button(vis, recorder.active)
+            if recorder.active:
+                recorder.write(frame, vis)
 
-    cap.release()
-    if writer is not None:
-        writer.release()
+            if writer is not None:
+                writer.write(vis)
+            if save_frames_dir and processed % max(1, save_frame_every) == 0:
+                cv2.imwrite(
+                    os.path.join(save_frames_dir, f"overlay_{processed:05d}.jpg"),
+                    vis,
+                    [int(cv2.IMWRITE_JPEG_QUALITY), 92],
+                )
+
+            if preview:
+                cv2.imshow(WINDOW_NAME, vis)
+                key = cv2.waitKey(1) & 0xFF
+                clicked = ui["click"]
+                ui["click"] = None
+                toggle_record = key in (ord("r"), ord("R"))
+                if clicked is not None and point_in_rect(clicked[0], clicked[1], button_rect):
+                    toggle_record = True
+                if toggle_record:
+                    rec_fps = live_fps if live_fps > 1 else 15.0
+                    recorder.toggle(width, height, rec_fps)
+                if key in (ord("q"), ord("Q"), 27):
+                    break
+
+            processed += 1
+            if max_frames and processed >= max_frames:
+                break
+            if processed % 30 == 0:
+                print(
+                    f"processed {processed} frames, lock={tracker.locked}, {live_fps:.1f} fps",
+                    flush=True,
+                )
+    finally:
+        if recorder.active:
+            recorder.stop()
+        cap.release()
+        if writer is not None:
+            writer.release()
+        if preview:
+            cv2.destroyAllWindows()
     return processed
 
 
@@ -183,6 +239,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--no-grid", action="store_true")
     parser.add_argument("--debug", action="store_true")
     parser.add_argument(
+        "--no-preview",
+        action="store_true",
+        help="Do not open a live window (useful for file-only processing).",
+    )
+    parser.add_argument(
         "--label",
         default="DEMO  numbered frets",
         help="HUD label drawn on the overlay.",
@@ -204,6 +265,13 @@ def main(argv: list[str] | None = None) -> int:
         label=args.label,
     )
     cap = open_source(args.source)
+    if not args.no_preview:
+        print(
+            "Live preview: point the camera at a guitar neck.\n"
+            "  REC button or R  start/stop recording (saves raw.mp4 + overlay.mp4)\n"
+            "  Q                quit",
+            flush=True,
+        )
     processed = process_stream(
         cap,
         detector,
@@ -214,6 +282,7 @@ def main(argv: list[str] | None = None) -> int:
         save_frames_dir=args.save_frames_dir,
         save_frame_every=args.save_frame_every,
         debug=args.debug,
+        preview=not args.no_preview,
     )
     print(f"done, {processed} frames")
     return 0 if processed else 1

--- a/fretboard_cam/fretboard_cam/detect.py
+++ b/fretboard_cam/fretboard_cam/detect.py
@@ -9,7 +9,7 @@ import cv2
 import numpy as np
 
 from .geometry import order_fretboard_corners, quad_from_contour
-from .neck import neck_quad_from_lines, neck_quad_from_mask
+from .neck import neck_quad_from_lines, neck_quad_from_mask, neck_quad_from_ridge
 
 
 @dataclass
@@ -79,8 +79,9 @@ def box_to_detection(
 ) -> Detection:
     """Turn a detector box into a neck quad.
 
-    Prefer a bundle of parallel string/neck lines. Fall back to GrabCut plus
-    a thin-region profile, then the box itself.
+    Prefer a bright maple ridge (neck on a dark shirt), then parallel
+    string/neck lines. Fall back to GrabCut plus a thin-region profile, then
+    the box itself.
     """
     h, w = frame.shape[:2]
     x1, y1, x2, y2 = [int(round(v)) for v in box_xyxy]
@@ -91,6 +92,15 @@ def box_to_detection(
             np.array([[x1, y2], [x2, y2], [x2, y1], [x1, y1]], dtype=np.float32)
         )
         return Detection(corners=corners, confidence=confidence, label=label, box_xyxy=box_xyxy)
+
+    ridge_quad = neck_quad_from_ridge(frame, box_xyxy)
+    if ridge_quad is not None:
+        return Detection(
+            corners=ridge_quad,
+            confidence=confidence,
+            label=f"{label}-ridge",
+            box_xyxy=box_xyxy,
+        )
 
     line_quad = neck_quad_from_lines(frame, box_xyxy)
     if line_quad is not None:
@@ -194,6 +204,18 @@ class ContourDetector:
             return None
         corners = quad_from_contour(contour)
         return Detection(corners=corners, confidence=0.6, label="contour")
+
+
+class RidgeDetector:
+    """Lock onto a maple neck as a bright ridge on a dark shirt. No neural net."""
+
+    name = "ridge"
+
+    def detect(self, frame: np.ndarray) -> Detection | None:
+        quad = neck_quad_from_ridge(frame)
+        if quad is None:
+            return None
+        return Detection(corners=quad, confidence=0.7, label="ridge")
 
 
 class YoloWorldDetector:
@@ -304,6 +326,8 @@ def build_detector(name: str, corners: np.ndarray | None = None) -> Detector:
         return ManualDetector(corners)
     if key == "contour":
         return ContourDetector()
+    if key == "ridge":
+        return RidgeDetector()
     if key in {"yolo-world", "yoloworld", "world"}:
         return YoloWorldDetector()
     if key in {"yolo-coco", "yolo", "coco"}:

--- a/fretboard_cam/fretboard_cam/detect.py
+++ b/fretboard_cam/fretboard_cam/detect.py
@@ -9,6 +9,7 @@ import cv2
 import numpy as np
 
 from .geometry import order_fretboard_corners, quad_from_contour
+from .neck import neck_quad_from_lines, neck_quad_from_mask
 
 
 @dataclass
@@ -62,7 +63,11 @@ def box_to_detection(
     confidence: float,
     label: str,
 ) -> Detection:
-    """Turn an axis-aligned box into a quad, refined with GrabCut when possible."""
+    """Turn a detector box into a neck quad.
+
+    Prefer a bundle of parallel string/neck lines. Fall back to GrabCut plus
+    a thin-region profile, then the box itself.
+    """
     h, w = frame.shape[:2]
     x1, y1, x2, y2 = [int(round(v)) for v in box_xyxy]
     x1, y1 = max(0, x1), max(0, y1)
@@ -73,13 +78,32 @@ def box_to_detection(
         )
         return Detection(corners=corners, confidence=confidence, label=label, box_xyxy=box_xyxy)
 
+    line_quad = neck_quad_from_lines(frame, box_xyxy)
+    if line_quad is not None:
+        return Detection(
+            corners=line_quad,
+            confidence=confidence,
+            label=f"{label}-lines",
+            box_xyxy=box_xyxy,
+        )
+
     rect = (x1, y1, x2 - x1, y2 - y1)
     mask = np.zeros(frame.shape[:2], np.uint8)
     bgd = np.zeros((1, 65), np.float64)
     fgd = np.zeros((1, 65), np.float64)
     try:
         cv2.grabCut(frame, mask, rect, bgd, fgd, 3, cv2.GC_INIT_WITH_RECT)
-        fg = np.where((mask == cv2.GC_FGD) | (mask == cv2.GC_PR_FGD), 255, 0).astype(np.uint8)
+        fg = np.where((mask == cv2.GC_FGD) | (mask == cv2.GC_PR_FGD), 255, 0).astype(
+            np.uint8
+        )
+        neck = neck_quad_from_mask(fg)
+        if neck is not None:
+            return Detection(
+                corners=neck,
+                confidence=confidence,
+                label=f"{label}-neck",
+                box_xyxy=box_xyxy,
+            )
         detection = mask_to_detection(
             fg, confidence=confidence, label=label, box_xyxy=box_xyxy
         )

--- a/fretboard_cam/fretboard_cam/detect.py
+++ b/fretboard_cam/fretboard_cam/detect.py
@@ -1,0 +1,255 @@
+"""Fretboard detectors. YOLO backends are optional; contour/manual always work."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+import cv2
+import numpy as np
+
+from .geometry import order_fretboard_corners, quad_from_contour
+
+
+@dataclass
+class Detection:
+    corners: np.ndarray
+    confidence: float
+    label: str
+    box_xyxy: np.ndarray | None = None
+
+
+class Detector(Protocol):
+    name: str
+
+    def detect(self, frame: np.ndarray) -> Detection | None: ...
+
+
+def _largest_contour(mask: np.ndarray, min_area: float) -> np.ndarray | None:
+    contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    if not contours:
+        return None
+    contour = max(contours, key=cv2.contourArea)
+    if cv2.contourArea(contour) < min_area:
+        return None
+    return contour
+
+
+def mask_to_detection(
+    mask: np.ndarray,
+    *,
+    confidence: float,
+    label: str,
+    box_xyxy: np.ndarray | None = None,
+) -> Detection | None:
+    min_area = 0.01 * mask.shape[0] * mask.shape[1]
+    contour = _largest_contour(mask, min_area)
+    if contour is None:
+        return None
+    corners = quad_from_contour(contour)
+    return Detection(
+        corners=corners,
+        confidence=confidence,
+        label=label,
+        box_xyxy=box_xyxy,
+    )
+
+
+def box_to_detection(
+    frame: np.ndarray,
+    box_xyxy: np.ndarray,
+    *,
+    confidence: float,
+    label: str,
+) -> Detection:
+    """Turn an axis-aligned box into a quad, refined with GrabCut when possible."""
+    h, w = frame.shape[:2]
+    x1, y1, x2, y2 = [int(round(v)) for v in box_xyxy]
+    x1, y1 = max(0, x1), max(0, y1)
+    x2, y2 = min(w - 1, x2), min(h - 1, y2)
+    if x2 <= x1 + 8 or y2 <= y1 + 8:
+        corners = order_fretboard_corners(
+            np.array([[x1, y2], [x2, y2], [x2, y1], [x1, y1]], dtype=np.float32)
+        )
+        return Detection(corners=corners, confidence=confidence, label=label, box_xyxy=box_xyxy)
+
+    rect = (x1, y1, x2 - x1, y2 - y1)
+    mask = np.zeros(frame.shape[:2], np.uint8)
+    bgd = np.zeros((1, 65), np.float64)
+    fgd = np.zeros((1, 65), np.float64)
+    try:
+        cv2.grabCut(frame, mask, rect, bgd, fgd, 3, cv2.GC_INIT_WITH_RECT)
+        fg = np.where((mask == cv2.GC_FGD) | (mask == cv2.GC_PR_FGD), 255, 0).astype(np.uint8)
+        detection = mask_to_detection(
+            fg, confidence=confidence, label=label, box_xyxy=box_xyxy
+        )
+        if detection is not None:
+            return detection
+    except cv2.error:
+        pass
+
+    crop_mask = np.zeros(frame.shape[:2], np.uint8)
+    crop_mask[y1:y2, x1:x2] = 255
+    detection = mask_to_detection(
+        crop_mask, confidence=confidence, label=label, box_xyxy=box_xyxy
+    )
+    if detection is not None:
+        return detection
+    corners = order_fretboard_corners(
+        np.array([[x1, y2], [x2, y2], [x2, y1], [x1, y1]], dtype=np.float32)
+    )
+    return Detection(corners=corners, confidence=confidence, label=label, box_xyxy=box_xyxy)
+
+
+class ManualDetector:
+    """Always returns the supplied corners. Useful for `--corners` and tests."""
+
+    name = "manual"
+
+    def __init__(self, corners: np.ndarray, confidence: float = 1.0):
+        self._detection = Detection(
+            corners=order_fretboard_corners(corners),
+            confidence=confidence,
+            label="manual",
+        )
+
+    def detect(self, frame: np.ndarray) -> Detection | None:
+        return self._detection
+
+
+class ContourDetector:
+    """Find a high-contrast elongated region. Works well on synthetic necks."""
+
+    name = "contour"
+
+    def __init__(self, min_aspect: float = 2.2):
+        self.min_aspect = min_aspect
+
+    def detect(self, frame: np.ndarray) -> Detection | None:
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        blur = cv2.GaussianBlur(gray, (5, 5), 0)
+        min_area = 0.02 * frame.shape[0] * frame.shape[1]
+
+        _, thresh = cv2.threshold(blur, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
+        # The fretboard should be the smaller of the two blobs on a typical shot.
+        if int(np.count_nonzero(thresh)) > thresh.size // 2:
+            thresh = cv2.bitwise_not(thresh)
+        thresh = cv2.morphologyEx(
+            thresh, cv2.MORPH_CLOSE, np.ones((7, 7), np.uint8), iterations=1
+        )
+
+        contour = _largest_contour(thresh, min_area)
+        if contour is None:
+            edges = cv2.Canny(blur, 40, 120)
+            edges = cv2.dilate(edges, np.ones((3, 3), np.uint8), iterations=1)
+            contour = _largest_contour(edges, min_area)
+            if contour is None:
+                return None
+
+        rect = cv2.minAreaRect(contour)
+        w, h = rect[1]
+        if min(w, h) < 1:
+            return None
+        aspect = max(w, h) / max(1.0, min(w, h))
+        if aspect < self.min_aspect:
+            return None
+        corners = quad_from_contour(contour)
+        return Detection(corners=corners, confidence=0.6, label="contour")
+
+
+class YoloWorldDetector:
+    """Open-vocabulary detector. No custom training — prompt for a guitar neck."""
+
+    name = "yolo-world"
+
+    def __init__(
+        self,
+        prompts: list[str] | None = None,
+        conf: float = 0.15,
+        model_name: str = "yolov8s-worldv2.pt",
+    ):
+        try:
+            from ultralytics import YOLOWorld
+        except ImportError as exc:
+            raise ImportError(
+                "ultralytics is required for yolo-world. "
+                "Install with: pip install -r fretboard_cam/requirements-ml.txt"
+            ) from exc
+        self.prompts = prompts or [
+            "guitar neck",
+            "guitar fretboard",
+            "fretboard",
+            "guitar",
+        ]
+        self.conf = conf
+        self.model = YOLOWorld(model_name)
+        self.model.set_classes(self.prompts)
+        self._preferred = {"guitar neck", "guitar fretboard", "fretboard"}
+
+    def detect(self, frame: np.ndarray) -> Detection | None:
+        results = self.model.predict(frame, conf=self.conf, verbose=False)
+        if not results:
+            return None
+        result = results[0]
+        if result.boxes is None or len(result.boxes) == 0:
+            return None
+
+        best_idx = None
+        best_score = -1.0
+        names = result.names
+        for i in range(len(result.boxes)):
+            cls_id = int(result.boxes.cls[i].item())
+            label = names.get(cls_id, str(cls_id))
+            conf = float(result.boxes.conf[i].item())
+            bonus = 0.25 if label in self._preferred else 0.0
+            score = conf + bonus
+            if score > best_score:
+                best_score = score
+                best_idx = i
+        if best_idx is None:
+            return None
+        box = result.boxes.xyxy[best_idx].cpu().numpy()
+        cls_id = int(result.boxes.cls[best_idx].item())
+        label = result.names.get(cls_id, "guitar")
+        conf = float(result.boxes.conf[best_idx].item())
+        return box_to_detection(frame, box, confidence=conf, label=label)
+
+
+class YoloCocoGuitarDetector:
+    """COCO-pretrained YOLO. Class 74 is guitar — no custom training."""
+
+    name = "yolo-coco"
+
+    def __init__(self, conf: float = 0.2, model_name: str = "yolov8s.pt"):
+        try:
+            from ultralytics import YOLO
+        except ImportError as exc:
+            raise ImportError(
+                "ultralytics is required for yolo-coco. "
+                "Install with: pip install -r fretboard_cam/requirements-ml.txt"
+            ) from exc
+        self.conf = conf
+        self.model = YOLO(model_name)
+
+    def detect(self, frame: np.ndarray) -> Detection | None:
+        results = self.model.predict(frame, conf=self.conf, verbose=False, classes=[74])
+        if not results or results[0].boxes is None or len(results[0].boxes) == 0:
+            return None
+        box = results[0].boxes.xyxy[0].cpu().numpy()
+        conf = float(results[0].boxes.conf[0].item())
+        return box_to_detection(frame, box, confidence=conf, label="guitar")
+
+
+def build_detector(name: str, corners: np.ndarray | None = None) -> Detector:
+    key = name.lower().replace("_", "-")
+    if key == "manual":
+        if corners is None:
+            raise ValueError("manual detector requires corners")
+        return ManualDetector(corners)
+    if key == "contour":
+        return ContourDetector()
+    if key in {"yolo-world", "yoloworld", "world"}:
+        return YoloWorldDetector()
+    if key in {"yolo-coco", "yolo", "coco"}:
+        return YoloCocoGuitarDetector()
+    raise ValueError(f"unknown detector: {name}")

--- a/fretboard_cam/fretboard_cam/detect.py
+++ b/fretboard_cam/fretboard_cam/detect.py
@@ -56,12 +56,26 @@ def mask_to_detection(
     )
 
 
+def _torch_device() -> str:
+    try:
+        import torch
+
+        if torch.backends.mps.is_available():
+            return "mps"
+        if torch.cuda.is_available():
+            return "cuda"
+    except Exception:
+        pass
+    return "cpu"
+
+
 def box_to_detection(
     frame: np.ndarray,
     box_xyxy: np.ndarray,
     *,
     confidence: float,
     label: str,
+    use_grabcut: bool = False,
 ) -> Detection:
     """Turn a detector box into a neck quad.
 
@@ -87,30 +101,31 @@ def box_to_detection(
             box_xyxy=box_xyxy,
         )
 
-    rect = (x1, y1, x2 - x1, y2 - y1)
-    mask = np.zeros(frame.shape[:2], np.uint8)
-    bgd = np.zeros((1, 65), np.float64)
-    fgd = np.zeros((1, 65), np.float64)
-    try:
-        cv2.grabCut(frame, mask, rect, bgd, fgd, 3, cv2.GC_INIT_WITH_RECT)
-        fg = np.where((mask == cv2.GC_FGD) | (mask == cv2.GC_PR_FGD), 255, 0).astype(
-            np.uint8
-        )
-        neck = neck_quad_from_mask(fg)
-        if neck is not None:
-            return Detection(
-                corners=neck,
-                confidence=confidence,
-                label=f"{label}-neck",
-                box_xyxy=box_xyxy,
+    if use_grabcut:
+        rect = (x1, y1, x2 - x1, y2 - y1)
+        mask = np.zeros(frame.shape[:2], np.uint8)
+        bgd = np.zeros((1, 65), np.float64)
+        fgd = np.zeros((1, 65), np.float64)
+        try:
+            cv2.grabCut(frame, mask, rect, bgd, fgd, 3, cv2.GC_INIT_WITH_RECT)
+            fg = np.where((mask == cv2.GC_FGD) | (mask == cv2.GC_PR_FGD), 255, 0).astype(
+                np.uint8
             )
-        detection = mask_to_detection(
-            fg, confidence=confidence, label=label, box_xyxy=box_xyxy
-        )
-        if detection is not None:
-            return detection
-    except cv2.error:
-        pass
+            neck = neck_quad_from_mask(fg)
+            if neck is not None:
+                return Detection(
+                    corners=neck,
+                    confidence=confidence,
+                    label=f"{label}-neck",
+                    box_xyxy=box_xyxy,
+                )
+            detection = mask_to_detection(
+                fg, confidence=confidence, label=label, box_xyxy=box_xyxy
+            )
+            if detection is not None:
+                return detection
+        except cv2.error:
+            pass
 
     crop_mask = np.zeros(frame.shape[:2], np.uint8)
     crop_mask[y1:y2, x1:x2] = 255
@@ -206,12 +221,20 @@ class YoloWorldDetector:
             "guitar",
         ]
         self.conf = conf
+        self.imgsz = 384
+        self.device = _torch_device()
         self.model = YOLOWorld(model_name)
         self.model.set_classes(self.prompts)
         self._preferred = {"guitar neck", "guitar fretboard", "fretboard"}
 
     def detect(self, frame: np.ndarray) -> Detection | None:
-        results = self.model.predict(frame, conf=self.conf, verbose=False)
+        results = self.model.predict(
+            frame,
+            conf=self.conf,
+            verbose=False,
+            imgsz=self.imgsz,
+            device=self.device,
+        )
         if not results:
             return None
         result = results[0]
@@ -244,7 +267,7 @@ class YoloCocoGuitarDetector:
 
     name = "yolo-coco"
 
-    def __init__(self, conf: float = 0.2, model_name: str = "yolov8s.pt"):
+    def __init__(self, conf: float = 0.2, model_name: str = "yolov8n.pt"):
         try:
             from ultralytics import YOLO
         except ImportError as exc:
@@ -253,10 +276,19 @@ class YoloCocoGuitarDetector:
                 "Install with: pip install -r fretboard_cam/requirements-ml.txt"
             ) from exc
         self.conf = conf
+        self.imgsz = 384
+        self.device = _torch_device()
         self.model = YOLO(model_name)
 
     def detect(self, frame: np.ndarray) -> Detection | None:
-        results = self.model.predict(frame, conf=self.conf, verbose=False, classes=[74])
+        results = self.model.predict(
+            frame,
+            conf=self.conf,
+            verbose=False,
+            classes=[74],
+            imgsz=self.imgsz,
+            device=self.device,
+        )
         if not results or results[0].boxes is None or len(results[0].boxes) == 0:
             return None
         box = results[0].boxes.xyxy[0].cpu().numpy()

--- a/fretboard_cam/fretboard_cam/geometry.py
+++ b/fretboard_cam/fretboard_cam/geometry.py
@@ -1,0 +1,174 @@
+"""Fretboard geometry: equal-temperament spacing, corner ordering, homography."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import cv2
+import numpy as np
+
+NUM_STRINGS = 6
+CANONICAL_CORNERS = np.array(
+    [
+        [0.0, 0.0],  # nut, bass
+        [1.0, 0.0],  # body, bass
+        [1.0, 1.0],  # body, treble
+        [0.0, 1.0],  # nut, treble
+    ],
+    dtype=np.float32,
+)
+
+
+def fret_distance_from_nut(fret: int, scale_length: float = 1.0) -> float:
+    """Distance from the nut to a fret using standard 12-TET placement."""
+    if fret < 0:
+        raise ValueError("fret must be >= 0")
+    return float(scale_length * (1.0 - 2.0 ** (-fret / 12.0)))
+
+
+def normalized_fret_xs(visible_frets: int) -> np.ndarray:
+    """x coordinates of the nut plus frets 1..visible_frets, mapped into [0, 1]."""
+    if visible_frets < 1:
+        raise ValueError("visible_frets must be >= 1")
+    end = fret_distance_from_nut(visible_frets)
+    xs = [0.0]
+    for fret in range(1, visible_frets + 1):
+        xs.append(fret_distance_from_nut(fret) / end)
+    return np.asarray(xs, dtype=np.float32)
+
+
+def string_number_to_lane(string_number: int, num_strings: int = NUM_STRINGS) -> int:
+    """Map guitar string number (1=high E, 6=low E) to a bass-origin lane index."""
+    if not 1 <= string_number <= num_strings:
+        raise ValueError(f"string_number must be in 1..{num_strings}")
+    return num_strings - string_number
+
+
+def string_center_y(string_number: int, num_strings: int = NUM_STRINGS) -> float:
+    """Canonical y of a string center. Bass (6) is near 0, treble (1) is near 1."""
+    lane = string_number_to_lane(string_number, num_strings)
+    return (lane + 0.5) / num_strings
+
+
+def cell_canonical_quad(
+    string_number: int,
+    fret: int,
+    visible_frets: int,
+    num_strings: int = NUM_STRINGS,
+) -> np.ndarray:
+    """Return the 4 canonical corners of the cell between fret-1 and fret.
+
+    Order: bass-nut-side, bass-body-side, treble-body-side, treble-nut-side.
+    """
+    if fret < 1:
+        raise ValueError("fret must be >= 1 (open string has no cell)")
+    if fret > visible_frets:
+        raise ValueError("fret cannot exceed visible_frets")
+    xs = normalized_fret_xs(visible_frets)
+    x0, x1 = float(xs[fret - 1]), float(xs[fret])
+    lane = string_number_to_lane(string_number, num_strings)
+    y0 = lane / num_strings
+    y1 = (lane + 1) / num_strings
+    return np.array(
+        [[x0, y0], [x1, y0], [x1, y1], [x0, y1]],
+        dtype=np.float32,
+    )
+
+
+def cell_canonical_center(
+    string_number: int,
+    fret: int,
+    visible_frets: int,
+    num_strings: int = NUM_STRINGS,
+) -> np.ndarray:
+    quad = cell_canonical_quad(string_number, fret, visible_frets, num_strings)
+    return quad.mean(axis=0).astype(np.float32)
+
+
+def order_fretboard_corners(points: Iterable[Iterable[float]]) -> np.ndarray:
+    """Order 4 points as nut_bass, body_bass, body_treble, nut_treble.
+
+    The long axis of the quad is treated as nut→body. The narrower end is the
+    nut when a taper is present; otherwise the end with smaller mean x wins
+    (typical camera framing with the headstock on the left).
+    """
+    pts = np.asarray(list(points), dtype=np.float32).reshape(4, 2)
+    mean = pts.mean(axis=0)
+    centered = pts - mean
+    cov = np.cov(centered.T)
+    eigvals, eigvecs = np.linalg.eigh(cov)
+    long_axis = eigvecs[:, int(np.argmax(eigvals))]
+    proj = centered @ long_axis
+    order = np.argsort(proj)
+    end_a = pts[order[:2]]
+    end_b = pts[order[2:]]
+
+    width_a = float(np.linalg.norm(end_a[0] - end_a[1]))
+    width_b = float(np.linalg.norm(end_b[0] - end_b[1]))
+    mean_a = end_a.mean(axis=0)
+    mean_b = end_b.mean(axis=0)
+
+    nut, body = end_a, end_b
+    if width_b < width_a * 0.92:
+        nut, body = end_b, end_a
+    elif width_a < width_b * 0.92:
+        nut, body = end_a, end_b
+    else:
+        # No clear taper: prefer the end that is more "headstock-left".
+        if mean_b[0] < mean_a[0]:
+            nut, body = end_b, end_a
+
+    nut = nut[np.argsort(nut[:, 1])]
+    body = body[np.argsort(body[:, 1])]
+    nut_treble, nut_bass = nut[0], nut[1]
+    body_treble, body_bass = body[0], body[1]
+    return np.stack([nut_bass, body_bass, body_treble, nut_treble]).astype(np.float32)
+
+
+def quad_from_min_area_rect(points: np.ndarray) -> np.ndarray:
+    """Fit a min-area rectangle to a point set and return ordered corners."""
+    pts = np.asarray(points, dtype=np.float32).reshape(-1, 2)
+    rect = cv2.minAreaRect(pts)
+    box = cv2.boxPoints(rect)
+    return order_fretboard_corners(box)
+
+
+def quad_from_contour(contour: np.ndarray) -> np.ndarray:
+    """Approximate a contour as an ordered fretboard quad."""
+    peri = cv2.arcLength(contour, True)
+    approx = cv2.approxPolyDP(contour, 0.04 * peri, True)
+    if len(approx) == 4:
+        return order_fretboard_corners(approx.reshape(4, 2))
+    return quad_from_min_area_rect(contour.reshape(-1, 2))
+
+
+def fretboard_homography(image_corners: np.ndarray) -> np.ndarray:
+    """Homography mapping canonical [0,1]x[0,1] onto the image quad."""
+    corners = np.asarray(image_corners, dtype=np.float32).reshape(4, 2)
+    matrix, _ = cv2.findHomography(CANONICAL_CORNERS, corners)
+    if matrix is None:
+        raise ValueError("could not compute fretboard homography")
+    return matrix.astype(np.float32)
+
+
+def canonical_to_image(points: np.ndarray, homography: np.ndarray) -> np.ndarray:
+    pts = np.asarray(points, dtype=np.float32).reshape(-1, 1, 2)
+    mapped = cv2.perspectiveTransform(pts, homography)
+    return mapped.reshape(-1, 2).astype(np.float32)
+
+
+def image_to_canonical(points: np.ndarray, homography: np.ndarray) -> np.ndarray:
+    inverse = np.linalg.inv(homography)
+    return canonical_to_image(points, inverse)
+
+
+def project_cell(
+    string_number: int,
+    fret: int,
+    image_corners: np.ndarray,
+    visible_frets: int,
+    num_strings: int = NUM_STRINGS,
+) -> np.ndarray:
+    homography = fretboard_homography(image_corners)
+    quad = cell_canonical_quad(string_number, fret, visible_frets, num_strings)
+    return canonical_to_image(quad, homography)

--- a/fretboard_cam/fretboard_cam/neck.py
+++ b/fretboard_cam/fretboard_cam/neck.py
@@ -1,0 +1,248 @@
+"""Isolate a guitar neck as a quadrilateral from a box or mask."""
+
+from __future__ import annotations
+
+import cv2
+import numpy as np
+
+from .geometry import order_fretboard_corners
+
+
+def _longest_true_run(flags: np.ndarray) -> tuple[int, int] | None:
+    best: tuple[int, int] | None = None
+    start = None
+    for i, flag in enumerate(list(flags) + [False]):
+        if flag and start is None:
+            start = i
+        elif not flag and start is not None:
+            run = (start, i)
+            if best is None or (run[1] - run[0]) > (best[1] - best[0]):
+                best = run
+            start = None
+    return best
+
+
+def _angle_diff_deg(a: float, b: float) -> float:
+    delta = abs(a - b) % 180.0
+    return min(delta, 180.0 - delta)
+
+
+def neck_quad_from_lines(
+    frame: np.ndarray,
+    box_xyxy: np.ndarray | None = None,
+    *,
+    min_line_length: float | None = None,
+) -> np.ndarray | None:
+    """Fit a fretboard quad from the densest bundle of long parallel lines.
+
+    Guitar strings (and neck edges) are a tight cluster of long segments
+    that share one angle. Frets are shorter and perpendicular, so they
+    lose the length-weighted vote.
+    """
+    if box_xyxy is not None:
+        x1, y1, x2, y2 = [int(round(v)) for v in box_xyxy]
+        x1, y1 = max(0, x1), max(0, y1)
+        x2, y2 = min(frame.shape[1] - 1, x2), min(frame.shape[0] - 1, y2)
+        if x2 <= x1 + 16 or y2 <= y1 + 16:
+            return None
+        crop = frame[y1:y2, x1:x2]
+        origin = np.array([x1, y1], dtype=np.float32)
+    else:
+        crop = frame
+        origin = np.array([0.0, 0.0], dtype=np.float32)
+
+    gray = cv2.cvtColor(crop, cv2.COLOR_BGR2GRAY) if crop.ndim == 3 else crop
+    gray = cv2.GaussianBlur(gray, (3, 3), 0)
+    lsd = cv2.createLineSegmentDetector()
+    detected = lsd.detect(gray)[0]
+    if detected is None:
+        return None
+    lines = detected.reshape(-1, 4).astype(np.float32)
+    if lines.shape[0] < 2:
+        return None
+
+    diag = float(np.hypot(crop.shape[1], crop.shape[0]))
+    min_len = min_line_length if min_line_length is not None else max(18.0, 0.045 * diag)
+
+    segs: list[tuple[float, float, np.ndarray]] = []
+    for x_a, y_a, x_b, y_b in lines:
+        length = float(np.hypot(x_b - x_a, y_b - y_a))
+        if length < min_len:
+            continue
+        angle = float(np.degrees(np.arctan2(y_b - y_a, x_b - x_a)) % 180.0)
+        segs.append((length, angle, np.array([x_a, y_a, x_b, y_b], dtype=np.float32)))
+    if len(segs) < 2:
+        return None
+
+    weights = np.zeros(36, dtype=np.float32)
+    for length, angle, _ in segs:
+        idx = min(35, int(angle / 5.0))
+        weights[idx] += length
+    dominant = float((int(np.argmax(weights)) + 0.5) * 5.0)
+
+    parallel = [s for s in segs if _angle_diff_deg(s[1], dominant) <= 12.0]
+    if len(parallel) < 2:
+        return None
+
+    theta = np.radians(dominant)
+    long_axis = np.array([np.cos(theta), np.sin(theta)], dtype=np.float32)
+    short_axis = np.array([-np.sin(theta), np.cos(theta)], dtype=np.float32)
+
+    mids = []
+    lengths = []
+    for length, _, coords in parallel:
+        a = coords[:2]
+        b = coords[2:]
+        mids.append((a + b) / 2.0)
+        lengths.append(length)
+    mids_arr = np.stack(mids)
+    lengths_arr = np.asarray(lengths, dtype=np.float32)
+    perp = mids_arr @ short_axis
+
+    span = float(perp.max() - perp.min())
+    if span < 4:
+        return None
+
+    endpoints = np.concatenate(
+        [np.stack([s[2][:2] for s in parallel]), np.stack([s[2][2:] for s in parallel])]
+    )
+    t_all = endpoints @ long_axis
+    length_all = float(t_all.max() - t_all.min())
+    aspect = length_all / max(span, 1.0)
+
+    use_all = 3.0 <= aspect <= 18.0 and span <= 0.45 * min(crop.shape[0], crop.shape[1])
+    if use_all:
+        pts_arr = endpoints
+    else:
+        neck_width_guess = float(
+            np.clip(0.28 * min(crop.shape[0], crop.shape[1]), 16.0, span)
+        )
+        order = np.argsort(perp)
+        perp_sorted = perp[order]
+        len_sorted = lengths_arr[order]
+        best_score = -1.0
+        best_lo = float(perp.min())
+        best_hi = float(perp.max())
+        j = 0
+        for i in range(len(perp_sorted)):
+            while (
+                j < len(perp_sorted)
+                and perp_sorted[j] - perp_sorted[i] <= neck_width_guess
+            ):
+                j += 1
+            score = float(len_sorted[i:j].sum())
+            if score > best_score:
+                best_score = score
+                best_lo = float(perp_sorted[i])
+                best_hi = float(perp_sorted[j - 1])
+
+        bundle_idx = [
+            k for k, p in enumerate(perp) if best_lo - 2 <= p <= best_hi + 2
+        ]
+        if len(bundle_idx) < 2:
+            return None
+        pts = []
+        for k in bundle_idx:
+            pts.append(parallel[k][2][:2])
+            pts.append(parallel[k][2][2:])
+        pts_arr = np.stack(pts)
+    t = pts_arr @ long_axis
+    w = pts_arr @ short_axis
+    t0, t1 = float(t.min()), float(t.max())
+    w0, w1 = float(w.min()), float(w.max())
+    trim = 0.06 * (t1 - t0)
+    t0 += trim
+    t1 -= trim
+    if t1 <= t0:
+        return None
+
+    corners_local = np.stack(
+        [
+            t0 * long_axis + w0 * short_axis,
+            t1 * long_axis + w0 * short_axis,
+            t1 * long_axis + w1 * short_axis,
+            t0 * long_axis + w1 * short_axis,
+        ]
+    ).astype(np.float32)
+    return order_fretboard_corners(corners_local + origin)
+
+
+def neck_quad_from_mask(
+    mask: np.ndarray,
+    *,
+    width_ratio: float = 0.42,
+    min_bins: int = 8,
+) -> np.ndarray | None:
+    """Return an ordered fretboard quad from a binary guitar mask.
+
+    Walks along the mask's long axis and keeps the longest run of *thin*
+    slices. That run is the neck; the body is the sudden wide section.
+    """
+    binary = (mask > 0).astype(np.uint8)
+    ys, xs = np.nonzero(binary)
+    if xs.size < 200:
+        return None
+
+    pts = np.column_stack([xs.astype(np.float32), ys.astype(np.float32)])
+    mean = pts.mean(axis=0)
+    centered = pts - mean
+    cov = np.cov(centered.T)
+    eigvals, eigvecs = np.linalg.eigh(cov)
+    long_axis = eigvecs[:, int(np.argmax(eigvals))]
+    short_axis = eigvecs[:, int(np.argmin(eigvals))]
+
+    t = centered @ long_axis
+    w = centered @ short_axis
+    t_min, t_max = float(t.min()), float(t.max())
+    if t_max - t_min < 20:
+        return None
+
+    n_bins = 48
+    edges = np.linspace(t_min, t_max, n_bins + 1)
+    widths = np.zeros(n_bins, dtype=np.float32)
+    counts = np.zeros(n_bins, dtype=np.int32)
+    for i in range(n_bins):
+        sel = (t >= edges[i]) & (t < edges[i + 1])
+        counts[i] = int(sel.sum())
+        if counts[i] >= 8:
+            widths[i] = float(w[sel].max() - w[sel].min())
+
+    valid = widths > 0
+    if int(valid.sum()) < min_bins:
+        return None
+    max_w = float(widths[valid].max())
+    median_w = float(np.median(widths[valid]))
+    threshold = max(max_w * width_ratio, median_w * 0.9)
+    thin = valid & (widths <= threshold)
+    run = _longest_true_run(thin)
+    if run is None or (run[1] - run[0]) < min_bins:
+        mid = (t_min + t_max) / 2.0
+        left_w = float(np.median(widths[valid][: max(1, n_bins // 2)]))
+        right_w = float(np.median(widths[valid][n_bins // 2 :]))
+        if left_w <= right_w:
+            neck_sel = t <= mid
+        else:
+            neck_sel = t >= mid
+    else:
+        neck_sel = (t >= edges[run[0]]) & (t < edges[run[1]])
+
+    neck_pts = pts[neck_sel]
+    if neck_pts.shape[0] < 80:
+        return None
+
+    neck_centered = neck_pts - neck_pts.mean(axis=0)
+    neck_t = neck_centered @ long_axis
+    end_frac = max(4, int(0.08 * neck_pts.shape[0]))
+    nut_side = neck_pts[np.argsort(neck_t)[:end_frac]]
+    body_side = neck_pts[np.argsort(neck_t)[-end_frac:]]
+
+    def _end_corners(end_pts: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        local = (end_pts - mean) @ short_axis
+        lo = end_pts[int(np.argmin(local))]
+        hi = end_pts[int(np.argmax(local))]
+        return lo, hi
+
+    nut_a, nut_b = _end_corners(nut_side)
+    body_a, body_b = _end_corners(body_side)
+    quad = np.stack([nut_a, body_a, body_b, nut_b]).astype(np.float32)
+    return order_fretboard_corners(quad)

--- a/fretboard_cam/fretboard_cam/neck.py
+++ b/fretboard_cam/fretboard_cam/neck.py
@@ -27,58 +27,205 @@ def _angle_diff_deg(a: float, b: float) -> float:
     return min(delta, 180.0 - delta)
 
 
+def _crop_from_box(
+    frame: np.ndarray, box_xyxy: np.ndarray | None
+) -> tuple[np.ndarray, np.ndarray] | None:
+    if box_xyxy is None:
+        return frame, np.array([0.0, 0.0], dtype=np.float32)
+    x1, y1, x2, y2 = [int(round(v)) for v in box_xyxy]
+    x1, y1 = max(0, x1), max(0, y1)
+    x2, y2 = min(frame.shape[1] - 1, x2), min(frame.shape[0] - 1, y2)
+    if x2 <= x1 + 16 or y2 <= y1 + 16:
+        return None
+    return frame[y1:y2, x1:x2], np.array([x1, y1], dtype=np.float32)
+
+
+def _box_long_axis_angle(crop: np.ndarray) -> float | None:
+    """Angle of a typical guitar in this crop: along the longer box side."""
+    h, w = crop.shape[:2]
+    if w >= h * 1.12:
+        return 0.0
+    if h >= w * 1.12:
+        return 90.0
+    return None
+
+
+def _collect_segments(gray: np.ndarray, min_len: float) -> list[tuple[float, float, np.ndarray]]:
+    segs: list[tuple[float, float, np.ndarray]] = []
+
+    def _add(x_a: float, y_a: float, x_b: float, y_b: float) -> None:
+        length = float(np.hypot(x_b - x_a, y_b - y_a))
+        if length < min_len:
+            return
+        angle = float(np.degrees(np.arctan2(y_b - y_a, x_b - x_a)) % 180.0)
+        segs.append((length, angle, np.array([x_a, y_a, x_b, y_b], dtype=np.float32)))
+
+    lsd = cv2.createLineSegmentDetector()
+    detected = lsd.detect(gray)[0]
+    if detected is not None:
+        for x_a, y_a, x_b, y_b in detected.reshape(-1, 4):
+            _add(float(x_a), float(y_a), float(x_b), float(y_b))
+
+    clahe = cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8))
+    enhanced = clahe.apply(gray)
+    edges = cv2.Canny(enhanced, 40, 120)
+    hough = cv2.HoughLinesP(
+        edges,
+        1,
+        np.pi / 180,
+        threshold=28,
+        minLineLength=int(max(24, min_len)),
+        maxLineGap=16,
+    )
+    if hough is not None:
+        for x_a, y_a, x_b, y_b in hough.reshape(-1, 4):
+            _add(float(x_a), float(y_a), float(x_b), float(y_b))
+    return segs
+
+
+def _dominant_angle(
+    segs: list[tuple[float, float, np.ndarray]],
+    prefer: float | None,
+) -> float | None:
+    if not segs:
+        return None
+    weights = np.zeros(36, dtype=np.float32)
+    for length, angle, _ in segs:
+        if prefer is not None and _angle_diff_deg(angle, prefer) > 50.0:
+            continue
+        boost = 1.0
+        if prefer is not None:
+            boost = 1.0 + 1.5 * (1.0 - _angle_diff_deg(angle, prefer) / 50.0)
+        idx = min(35, int(angle / 5.0))
+        weights[idx] += length * boost
+    if float(weights.max()) <= 0:
+        for length, angle, _ in segs:
+            idx = min(35, int(angle / 5.0))
+            weights[idx] += length
+        if float(weights.max()) <= 0:
+            return None
+    return float((int(np.argmax(weights)) + 0.5) * 5.0)
+
+
+def _merge_rails(
+    parallel: list[tuple[float, float, np.ndarray]],
+    long_axis: np.ndarray,
+    short_axis: np.ndarray,
+    bin_w: float = 6.0,
+) -> list[dict[str, float]]:
+    mids = np.stack([(s[2][:2] + s[2][2:]) / 2.0 for s in parallel])
+    perp = mids @ short_axis
+    order = np.argsort(perp)
+    rails: list[dict[str, float]] = []
+    i = 0
+    while i < len(order):
+        j = i
+        ps = [float(perp[order[i]])]
+        length_sum = parallel[order[i]][0]
+        ts = [
+            float(parallel[order[i]][2][:2] @ long_axis),
+            float(parallel[order[i]][2][2:] @ long_axis),
+        ]
+        while j + 1 < len(order) and float(perp[order[j + 1]] - perp[order[i]]) <= bin_w:
+            j += 1
+            ps.append(float(perp[order[j]]))
+            length_sum += parallel[order[j]][0]
+            ts.append(float(parallel[order[j]][2][:2] @ long_axis))
+            ts.append(float(parallel[order[j]][2][2:] @ long_axis))
+        rails.append(
+            {
+                "p": float(np.mean(ps)),
+                "t0": float(min(ts)),
+                "t1": float(max(ts)),
+                "L": float(length_sum),
+            }
+        )
+        i = j + 1
+    return rails
+
+
+def _band_stats(
+    value: np.ndarray,
+    sat: np.ndarray,
+    long_axis: np.ndarray,
+    short_axis: np.ndarray,
+    t: float,
+    w0: float,
+    w1: float,
+    samples: int = 7,
+) -> tuple[float, float]:
+    h, w = value.shape[:2]
+    ws = np.linspace(w0, w1, samples)
+    xs = []
+    ys = []
+    for wv in ws:
+        pt = t * long_axis + wv * short_axis
+        xs.append(pt[0])
+        ys.append(pt[1])
+    xi = np.clip(np.round(xs).astype(int), 0, w - 1)
+    yi = np.clip(np.round(ys).astype(int), 0, h - 1)
+    return float(value[yi, xi].mean()), float(sat[yi, xi].mean())
+
+
+def _is_fretboard_interior(vmean: float, smean: float) -> bool:
+    """Maple / light wood: bright enough to not be a pickguard, not a lamp flare."""
+    if vmean < 118.0 or vmean > 230.0:
+        return False
+    if smean < 16.0:
+        return False
+    return True
+
+
+def _corners_from_axes(
+    t0: float,
+    t1: float,
+    w0: float,
+    w1: float,
+    long_axis: np.ndarray,
+    short_axis: np.ndarray,
+    origin: np.ndarray,
+) -> np.ndarray:
+    corners_local = np.stack(
+        [
+            t0 * long_axis + w0 * short_axis,
+            t1 * long_axis + w0 * short_axis,
+            t1 * long_axis + w1 * short_axis,
+            t0 * long_axis + w1 * short_axis,
+        ]
+    ).astype(np.float32)
+    return order_fretboard_corners(corners_local + origin)
+
+
 def neck_quad_from_lines(
     frame: np.ndarray,
     box_xyxy: np.ndarray | None = None,
     *,
     min_line_length: float | None = None,
 ) -> np.ndarray | None:
-    """Fit a fretboard quad from the densest bundle of long parallel lines.
+    """Fit a fretboard quad from parallel neck-edge / string lines.
 
-    Guitar strings (and neck edges) are a tight cluster of long segments
-    that share one angle. Frets are shorter and perpendicular, so they
-    lose the length-weighted vote.
+    High-contrast pickguard strings often outvote the maple neck, so candidate
+    bundles are scored by *interior brightness* (light wood, not a dark
+    pickguard or blown-out lamp) and a plausible neck width. The YOLO guitar
+    box's long axis is used as an angle prior so bookshelf edges lose.
     """
-    if box_xyxy is not None:
-        x1, y1, x2, y2 = [int(round(v)) for v in box_xyxy]
-        x1, y1 = max(0, x1), max(0, y1)
-        x2, y2 = min(frame.shape[1] - 1, x2), min(frame.shape[0] - 1, y2)
-        if x2 <= x1 + 16 or y2 <= y1 + 16:
-            return None
-        crop = frame[y1:y2, x1:x2]
-        origin = np.array([x1, y1], dtype=np.float32)
-    else:
-        crop = frame
-        origin = np.array([0.0, 0.0], dtype=np.float32)
+    cropped = _crop_from_box(frame, box_xyxy)
+    if cropped is None:
+        return None
+    crop, origin = cropped
 
     gray = cv2.cvtColor(crop, cv2.COLOR_BGR2GRAY) if crop.ndim == 3 else crop
     gray = cv2.GaussianBlur(gray, (3, 3), 0)
-    lsd = cv2.createLineSegmentDetector()
-    detected = lsd.detect(gray)[0]
-    if detected is None:
-        return None
-    lines = detected.reshape(-1, 4).astype(np.float32)
-    if lines.shape[0] < 2:
-        return None
-
     diag = float(np.hypot(crop.shape[1], crop.shape[0]))
     min_len = min_line_length if min_line_length is not None else max(18.0, 0.045 * diag)
-
-    segs: list[tuple[float, float, np.ndarray]] = []
-    for x_a, y_a, x_b, y_b in lines:
-        length = float(np.hypot(x_b - x_a, y_b - y_a))
-        if length < min_len:
-            continue
-        angle = float(np.degrees(np.arctan2(y_b - y_a, x_b - x_a)) % 180.0)
-        segs.append((length, angle, np.array([x_a, y_a, x_b, y_b], dtype=np.float32)))
+    segs = _collect_segments(gray, min_len)
     if len(segs) < 2:
         return None
 
-    weights = np.zeros(36, dtype=np.float32)
-    for length, angle, _ in segs:
-        idx = min(35, int(angle / 5.0))
-        weights[idx] += length
-    dominant = float((int(np.argmax(weights)) + 0.5) * 5.0)
+    prefer = _box_long_axis_angle(crop)
+    dominant = _dominant_angle(segs, prefer)
+    if dominant is None:
+        return None
 
     parallel = [s for s in segs if _angle_diff_deg(s[1], dominant) <= 12.0]
     if len(parallel) < 2:
@@ -87,35 +234,162 @@ def neck_quad_from_lines(
     theta = np.radians(dominant)
     long_axis = np.array([np.cos(theta), np.sin(theta)], dtype=np.float32)
     short_axis = np.array([-np.sin(theta), np.cos(theta)], dtype=np.float32)
+    rails = _merge_rails(parallel, long_axis, short_axis)
+    if len(rails) < 2:
+        return None
 
-    mids = []
-    lengths = []
-    for length, _, coords in parallel:
-        a = coords[:2]
-        b = coords[2:]
-        mids.append((a + b) / 2.0)
-        lengths.append(length)
-    mids_arr = np.stack(mids)
-    lengths_arr = np.asarray(lengths, dtype=np.float32)
-    perp = mids_arr @ short_axis
+    if crop.ndim == 3:
+        hsv = cv2.cvtColor(crop, cv2.COLOR_BGR2HSV)
+        value = hsv[:, :, 2].astype(np.float32)
+        sat = hsv[:, :, 1].astype(np.float32)
+    else:
+        value = gray.astype(np.float32)
+        sat = np.full_like(value, 80.0)
 
+    min_w = max(32.0, 0.06 * min(crop.shape[:2]))
+    max_w = max(min_w + 16.0, 0.26 * min(crop.shape[:2]))
+    best: tuple[float, dict[str, float], dict[str, float], float, float] | None = None
+
+    for i, rail_a in enumerate(rails):
+        for rail_b in rails[i + 1 :]:
+            width = float(rail_b["p"] - rail_a["p"])
+            if not (min_w <= width <= max_w):
+                continue
+            overlap_t0 = max(rail_a["t0"], rail_b["t0"])
+            overlap_t1 = min(rail_a["t1"], rail_b["t1"])
+            overlap = overlap_t1 - overlap_t0
+            if overlap >= 48:
+                t0, t1 = overlap_t0, overlap_t1
+            else:
+                t0 = min(rail_a["t0"], rail_b["t0"])
+                t1 = max(rail_a["t1"], rail_b["t1"])
+            span = t1 - t0
+            if span < 80:
+                continue
+            aspect = span / max(width, 1.0)
+            if aspect < 3.0:
+                continue
+            inset = 0.16 * width
+            ts = np.linspace(t0 + 0.08 * span, t1 - 0.08 * span, 28)
+            ok_v: list[float] = []
+            ok_s: list[float] = []
+            ok_t: list[float] = []
+            for t in ts:
+                vmean, smean = _band_stats(
+                    value,
+                    sat,
+                    long_axis,
+                    short_axis,
+                    float(t),
+                    rail_a["p"] + inset,
+                    rail_b["p"] - inset,
+                )
+                if _is_fretboard_interior(vmean, smean):
+                    ok_v.append(vmean)
+                    ok_s.append(smean)
+                    ok_t.append(float(t))
+            # Strings continue onto the pickguard, so the full-span mean is dark.
+            # Keep pairs that have a long enough maple stretch.
+            if len(ok_v) < 8:
+                continue
+            vmean = float(np.mean(ok_v))
+            smean = float(np.mean(ok_s))
+            maple_span = float(max(ok_t) - min(ok_t)) if len(ok_t) >= 2 else 0.0
+            maple_aspect = maple_span / max(width, 1.0)
+            if maple_aspect < 2.8:
+                continue
+            inner = sum(1 for r in rails if rail_a["p"] < r["p"] < rail_b["p"])
+            mid_t = float(np.median(np.asarray(ok_t)))
+            mid_w = 0.5 * (rail_a["p"] + rail_b["p"])
+            mid_xy = mid_t * long_axis + mid_w * short_axis
+            left_bonus = 35.0 * (1.0 - float(mid_xy[0]) / max(crop.shape[1], 1))
+            top_bonus = 0.0
+            if crop.shape[1] >= crop.shape[0] * 1.12:
+                top_bonus = 55.0 * (1.0 - float(mid_xy[1]) / max(crop.shape[0], 1))
+            score = (
+                width * 1.6
+                + min(maple_aspect, 14.0) * 10.0
+                + 0.2 * vmean
+                + 0.012 * (rail_a["L"] + rail_b["L"])
+                + 8.0 * min(inner, 6)
+                + left_bonus
+                + top_bonus
+            )
+            if 140.0 <= vmean <= 190.0:
+                score += 20.0
+            if best is None or score > best[0]:
+                best = (score, rail_a, rail_b, t0, t1)
+
+    if best is not None:
+        _score, rail_a, rail_b, t0, t1 = best
+        width = float(rail_b["p"] - rail_a["p"])
+        inset = 0.10 * width
+        w0 = float(rail_a["p"] + inset)
+        w1 = float(rail_b["p"] - inset)
+        scan_inset = 0.22 * width
+        sw0 = float(rail_a["p"] + scan_inset)
+        sw1 = float(rail_b["p"] - scan_inset)
+        if sw1 <= sw0:
+            sw0, sw1 = w0, w1
+        # Rails often continue onto the pickguard. Keep the longest maple run.
+        endpoints = np.concatenate(
+            [np.stack([s[2][:2] for s in parallel]), np.stack([s[2][2:] for s in parallel])]
+        )
+        t_scan0 = float((endpoints @ long_axis).min())
+        t_scan1 = float((endpoints @ long_axis).max())
+        step = 8.0
+        ts = np.arange(t_scan0, t_scan1 + step, step)
+        flags = []
+        for t in ts:
+            vmean, smean = _band_stats(value, sat, long_axis, short_axis, float(t), sw0, sw1)
+            flags.append(_is_fretboard_interior(vmean, smean))
+        # Frets and fingers punch small holes; keep one run for the whole neck.
+        flags_arr = np.asarray(flags, dtype=bool)
+        for i in range(1, len(flags_arr) - 1):
+            if flags_arr[i - 1] and flags_arr[i + 1]:
+                flags_arr[i] = True
+        for i in range(2, len(flags_arr) - 2):
+            if flags_arr[i - 2] and flags_arr[i + 2]:
+                flags_arr[i] = True
+        run = _longest_true_run(flags_arr)
+        if run is not None and (run[1] - run[0]) >= 6:
+            t0 = float(ts[run[0]])
+            t1 = float(ts[min(run[1] - 1, len(ts) - 1)])
+        trim = 0.04 * max(t1 - t0, 1.0)
+        t0 += trim
+        t1 -= trim
+        if t1 > t0:
+            return _corners_from_axes(t0, t1, w0, w1, long_axis, short_axis, origin)
+
+    return _neck_quad_from_line_envelope(parallel, long_axis, short_axis, crop, origin)
+
+
+def _neck_quad_from_line_envelope(
+    parallel: list[tuple[float, float, np.ndarray]],
+    long_axis: np.ndarray,
+    short_axis: np.ndarray,
+    crop: np.ndarray,
+    origin: np.ndarray,
+) -> np.ndarray | None:
+    """Legacy fallback: densest parallel bundle when wood scoring finds nothing."""
+    mids = np.stack([(s[2][:2] + s[2][2:]) / 2.0 for s in parallel])
+    lengths_arr = np.asarray([s[0] for s in parallel], dtype=np.float32)
+    perp = mids @ short_axis
     span = float(perp.max() - perp.min())
     if span < 4:
         return None
-
     endpoints = np.concatenate(
         [np.stack([s[2][:2] for s in parallel]), np.stack([s[2][2:] for s in parallel])]
     )
     t_all = endpoints @ long_axis
     length_all = float(t_all.max() - t_all.min())
     aspect = length_all / max(span, 1.0)
-
-    use_all = 3.0 <= aspect <= 18.0 and span <= 0.45 * min(crop.shape[0], crop.shape[1])
+    use_all = 3.0 <= aspect <= 18.0 and span <= 0.28 * min(crop.shape[0], crop.shape[1])
     if use_all:
         pts_arr = endpoints
     else:
         neck_width_guess = float(
-            np.clip(0.28 * min(crop.shape[0], crop.shape[1]), 16.0, span)
+            np.clip(0.16 * min(crop.shape[0], crop.shape[1]), 28.0, span)
         )
         order = np.argsort(perp)
         perp_sorted = perp[order]
@@ -135,10 +409,7 @@ def neck_quad_from_lines(
                 best_score = score
                 best_lo = float(perp_sorted[i])
                 best_hi = float(perp_sorted[j - 1])
-
-        bundle_idx = [
-            k for k, p in enumerate(perp) if best_lo - 2 <= p <= best_hi + 2
-        ]
+        bundle_idx = [k for k, p in enumerate(perp) if best_lo - 2 <= p <= best_hi + 2]
         if len(bundle_idx) < 2:
             return None
         pts = []
@@ -155,16 +426,7 @@ def neck_quad_from_lines(
     t1 -= trim
     if t1 <= t0:
         return None
-
-    corners_local = np.stack(
-        [
-            t0 * long_axis + w0 * short_axis,
-            t1 * long_axis + w0 * short_axis,
-            t1 * long_axis + w1 * short_axis,
-            t0 * long_axis + w1 * short_axis,
-        ]
-    ).astype(np.float32)
-    return order_fretboard_corners(corners_local + origin)
+    return _corners_from_axes(t0, t1, w0, w1, long_axis, short_axis, origin)
 
 
 def neck_quad_from_mask(

--- a/fretboard_cam/fretboard_cam/neck.py
+++ b/fretboard_cam/fretboard_cam/neck.py
@@ -27,6 +27,25 @@ def _angle_diff_deg(a: float, b: float) -> float:
     return min(delta, 180.0 - delta)
 
 
+def _expand_box(
+    frame: np.ndarray, box_xyxy: np.ndarray | None, *, left: float = 0.38
+) -> np.ndarray | None:
+    """Pad a YOLO guitar box left/vertically so the headstock is not clipped."""
+    h, w = frame.shape[:2]
+    if box_xyxy is None:
+        return None
+    x1, y1, x2, y2 = [int(round(v)) for v in box_xyxy]
+    bw = max(x2 - x1, 1)
+    bh = max(y2 - y1, 1)
+    x1 = max(0, x1 - int(left * bw))
+    x2 = min(w - 1, x2 + int(0.05 * bw))
+    y1 = max(0, y1 - int(0.24 * bh))
+    y2 = min(h - 1, y2 + int(0.24 * bh))
+    if x2 <= x1 + 16 or y2 <= y1 + 16:
+        return None
+    return np.array([x1, y1, x2, y2], dtype=np.float32)
+
+
 def _crop_from_box(
     frame: np.ndarray, box_xyxy: np.ndarray | None
 ) -> tuple[np.ndarray, np.ndarray] | None:
@@ -48,6 +67,313 @@ def _box_long_axis_angle(crop: np.ndarray) -> float | None:
     if h >= w * 1.12:
         return 90.0
     return None
+
+
+def _fill_1d_holes(flags: np.ndarray, radius: int = 2) -> np.ndarray:
+    out = flags.copy()
+    for _ in range(radius):
+        nxt = out.copy()
+        for i in range(1, len(out) - 1):
+            if out[i - 1] and out[i + 1]:
+                nxt[i] = True
+        out = nxt
+    return out
+
+
+def _ridge_response(val: np.ndarray, sat: np.ndarray, hw: int, flank: int) -> np.ndarray:
+    """Bright band with a darker underside (maple neck on a black shirt)."""
+    k_in = np.ones((2 * hw, 1), np.float32) / float(2 * hw)
+    inside = cv2.filter2D(val, -1, k_in, borderType=cv2.BORDER_REPLICATE)
+    k_f = np.ones((flank, 1), np.float32) / float(flank)
+    flank_mean = cv2.filter2D(val, -1, k_f, borderType=cv2.BORDER_REPLICATE)
+    shift = hw + flank // 2
+    above = np.roll(flank_mean, -shift, axis=0)
+    below = np.roll(flank_mean, shift, axis=0)
+    ridge = (inside - below) + 0.4 * np.maximum(inside - above, 0.0)
+    ridge = np.maximum(ridge, 0.0)
+    ridge[: shift + 2] = 0
+    ridge[-(shift + 2) :] = 0
+    maple = ((sat >= 16) & (sat <= 145) & (val >= 125)).astype(np.float32)
+    ridge *= 0.22 + 0.78 * cv2.blur(maple, (17, 9))
+    return ridge
+
+
+def _expand_plateau(
+    col: np.ndarray, y_mid: int, min_w: int, max_w: int
+) -> tuple[int, int] | None:
+    """Grow from a centerline pixel to the bright-wood plateau, ignoring thin strings."""
+    h = int(col.shape[0])
+    y_mid = int(np.clip(y_mid, 1, h - 2))
+    peak_v = float(col[y_mid])
+    thresh = max(128.0, peak_v - 70.0)
+    bright = _fill_1d_holes(col > thresh, radius=2)
+    if not bright[y_mid]:
+        found = None
+        for d in range(1, max(10, min_w // 2)):
+            if y_mid - d >= 0 and bright[y_mid - d]:
+                found = y_mid - d
+                break
+            if y_mid + d < h and bright[y_mid + d]:
+                found = y_mid + d
+                break
+        if found is None:
+            return None
+        y_mid = found
+        peak_v = float(col[y_mid])
+        thresh = max(128.0, peak_v - 70.0)
+        bright = _fill_1d_holes(col > thresh, radius=2)
+    y_top = y_mid
+    y_bot = y_mid
+    limit_t = max(1, y_mid - max_w)
+    limit_b = min(h - 2, y_mid + max_w)
+    while y_top > limit_t and bright[y_top - 1]:
+        y_top -= 1
+    while y_bot < limit_b and bright[y_bot + 1]:
+        y_bot += 1
+    if (y_bot - y_top) < min_w:
+        return None
+    return y_top, y_bot
+
+
+def _theil_sen(xs: np.ndarray, ys: np.ndarray) -> tuple[float, float]:
+    """Robust y = slope * x + intercept."""
+    n = len(xs)
+    slopes: list[float] = []
+    step = 1 if n < 40 else 2
+    for i in range(0, n - 1, step):
+        for j in range(i + step, n, step):
+            dx = float(xs[j] - xs[i])
+            if abs(dx) < 8:
+                continue
+            slopes.append(float(ys[j] - ys[i]) / dx)
+    if not slopes:
+        slope = 0.0
+    else:
+        slope = float(np.median(np.asarray(slopes)))
+    intercept = float(np.median(ys - slope * xs))
+    return slope, intercept
+
+
+def _fit_quad_from_bands(
+    xs: np.ndarray,
+    tops: np.ndarray,
+    bots: np.ndarray,
+    origin: np.ndarray,
+    min_span: float,
+    val: np.ndarray | None = None,
+    sat: np.ndarray | None = None,
+) -> np.ndarray | None:
+    if len(xs) < 10:
+        return None
+    widths = bots - tops
+    med_w = float(np.median(widths))
+    ok = np.abs(widths - med_w) < 0.45 * max(med_w, 1.0)
+    ok = _fill_1d_holes(ok, radius=2)
+    run = _longest_true_run(ok)
+    if run is None or (run[1] - run[0]) < 8:
+        return None
+    sl = slice(run[0], run[1])
+    xs, tops, bots = xs[sl], tops[sl], bots[sl]
+    if float(xs.max() - xs.min()) < min_span:
+        return None
+    mids = 0.5 * (tops + bots)
+    # Prefer the outer neck edges, not an inner string pair.
+    widths = bots - tops
+    med_w = float(np.percentile(widths, 72))
+    slope, intercept = _theil_sen(xs, mids)
+    # Dark-below matching sits a little low; nudge onto the maple.
+    intercept -= 0.12 * med_w
+    x0, x1 = float(xs.min()), float(xs.max())
+    if val is not None and sat is not None:
+        crop_h, crop_w = val.shape[:2]
+        misses = 0
+        x_scan = x1
+        x_limit = min(float(crop_w - 4), x1 + 0.45 * crop_w)
+        while x_scan + 4 <= x_limit:
+            x_scan += 4
+            y_mid = intercept + slope * x_scan
+            yi = int(np.clip(round(y_mid), 2, crop_h - 3))
+            xi = int(np.clip(x_scan, 0, crop_w - 1))
+            band_t = int(np.clip(yi - 0.45 * med_w, 0, crop_h - 1))
+            band_b = int(np.clip(yi + 0.45 * med_w, 0, crop_h - 1))
+            if band_b <= band_t + 4:
+                break
+            interior = float(val[band_t:band_b, xi].mean())
+            smean = float(sat[band_t:band_b, xi].mean())
+            if interior < 128 or smean > 150:
+                misses += 1
+                if misses >= 4:
+                    break
+                continue
+            misses = 0
+            x1 = x_scan
+    pad = 0.008 * max(x1 - x0, 1.0)
+    x0 += pad
+    x1 -= pad
+    if x1 <= x0:
+        return None
+    # Offset along image-y is fine for near-horizontal necks; correct a bit for slope.
+    half = 0.5 * med_w
+    denom = float(np.hypot(slope, 1.0))
+    dy = half / denom
+    dx = -slope * dy
+    mid0 = intercept + slope * x0
+    mid1 = intercept + slope * x1
+    quad = np.array(
+        [
+            [x0 - dx, mid0 + dy],
+            [x1 - dx, mid1 + dy],
+            [x1 + dx, mid1 - dy],
+            [x0 + dx, mid0 - dy],
+        ],
+        dtype=np.float32,
+    )
+    return order_fretboard_corners(quad + origin)
+
+
+def neck_quad_from_ridge(
+    frame: np.ndarray,
+    box_xyxy: np.ndarray | None = None,
+) -> np.ndarray | None:
+    """Fit a fretboard quad to a bright maple ridge sitting on a dark shirt.
+
+    YOLO's guitar box often covers the whole instrument and clips the
+    headstock, so the search region is expanded left. A matched filter finds
+    the chest-height ridge, then the centerline is tracked along x so a tilted
+    neck is followed out to the pickguard.
+    """
+    expanded = _expand_box(frame, box_xyxy) if box_xyxy is not None else None
+    cropped = _crop_from_box(frame, expanded)
+    if cropped is None:
+        return None
+    crop, origin = cropped
+    if crop.shape[0] < 40 or crop.shape[1] < 80:
+        return None
+
+    h_full, w_full = frame.shape[:2]
+    hsv = cv2.cvtColor(crop, cv2.COLOR_BGR2HSV) if crop.ndim == 3 else None
+    if hsv is None:
+        val = crop.astype(np.float32)
+        sat = np.full_like(val, 70.0)
+    else:
+        val = hsv[:, :, 2].astype(np.float32)
+        sat = hsv[:, :, 1].astype(np.float32)
+    vsm = cv2.GaussianBlur(val, (5, 7), 0)
+    ch, cw = val.shape
+    hw = max(22, int(0.055 * h_full))
+    flank = max(16, int(0.032 * h_full))
+    ridge = _ridge_response(val, sat, hw, flank)
+
+    x_lo_s = int(0.05 * cw)
+    x_hi_s = int(0.58 * cw)
+    if x_hi_s <= x_lo_s + 16:
+        x_lo_s, x_hi_s = 0, cw
+    kxw = max(21, int(0.14 * cw) | 1)
+    horiz = cv2.blur(ridge, (kxw, 1))
+    horiz = cv2.GaussianBlur(horiz, (1, 9), 0)
+    row_score = np.percentile(horiz[:, x_lo_s:x_hi_s], 80, axis=1)
+    y0, y1 = int(0.28 * ch), int(0.78 * ch)
+    if y1 <= y0 + 8:
+        return None
+    y_peak = y0 + int(np.argmax(row_score[y0:y1]))
+    peak = float(row_score[y_peak])
+    if peak < 5.0:
+        return None
+
+    seed_band = ridge[max(0, y_peak - 10) : min(ch, y_peak + 11), x_lo_s:x_hi_s]
+    if seed_band.size == 0:
+        return None
+    seed_x = x_lo_s + int(np.argmax(seed_band.max(axis=0)))
+    shift = hw + flank // 2
+    win = max(28, int(0.09 * h_full))
+    min_w = max(22, int(0.048 * h_full))
+    max_w = max(min_w + 8, int(0.22 * h_full))
+
+    def _walk(x_start: int, y_start: float, x_end: int, step: int) -> list[tuple[int, int, int]]:
+        pts: list[tuple[int, int, int]] = []
+        pred = float(y_start)
+        misses = 0
+        x = x_start
+        while (step > 0 and x <= x_end) or (step < 0 and x >= x_end):
+            y_a = int(np.clip(pred - win, shift + 2, ch - shift - 6))
+            y_b = int(np.clip(pred + win, y_a + 6, ch - shift - 3))
+            strip = ridge[y_a:y_b, x]
+            y_loc = y_a + int(np.argmax(strip))
+            strength = float(strip.max())
+            y_for_band = y_loc if strength >= 7 else int(round(pred))
+            expanded = _expand_plateau(vsm[:, x], y_for_band, min_w, max_w)
+            if expanded is None:
+                if strength >= 7:
+                    pred = 0.7 * pred + 0.3 * y_loc
+                misses += 1
+                if misses >= 16:
+                    break
+                x += step
+                continue
+            y_top, y_bot = expanded
+            interior = float(vsm[y_top:y_bot, x].mean())
+            smean = float(sat[y_top:y_bot, x].mean())
+            # Pickguard / body: dark or very saturated butterscotch.
+            if interior < 122 or smean > 152:
+                if strength >= 7:
+                    pred = 0.7 * pred + 0.3 * y_loc
+                misses += 1
+                if misses >= 7 and pts:
+                    break
+                x += step
+                continue
+            misses = 0
+            pred = 0.55 * pred + 0.45 * (0.5 * (y_top + y_bot))
+            pts.append((x, y_top, y_bot))
+            x += step
+        return pts
+
+    right = _walk(seed_x, float(y_peak), cw - 4, 3)
+    left = _walk(seed_x - 3, float(y_peak), 3, -3)
+    samples = list(reversed(left)) + right
+    if len(samples) < 14:
+        return None
+    xs = np.array([p[0] for p in samples], dtype=np.float32)
+    tops = np.array([p[1] for p in samples], dtype=np.float32)
+    bots = np.array([p[2] for p in samples], dtype=np.float32)
+    mids = 0.5 * (tops + bots)
+    near = np.abs(mids - float(y_peak)) < 0.16 * ch
+    if int(near.sum()) >= 12:
+        xs, tops, bots = xs[near], tops[near], bots[near]
+        samples = [p for p, keep in zip(samples, near) if keep]
+    mids = 0.5 * (tops + bots)
+    slope, intercept = _theil_sen(xs, mids)
+    med_w = float(np.median(bots - tops))
+    extra: list[tuple[int, int, int]] = []
+    misses = 0
+    x_right = int(xs.max())
+    for x in range(x_right + 3, min(cw - 4, x_right + int(0.42 * cw)), 3):
+        y_mid = int(round(intercept + slope * x))
+        expanded = _expand_plateau(vsm[:, x], y_mid, min_w, max_w)
+        if expanded is None:
+            misses += 1
+            if misses >= 8:
+                break
+            continue
+        y_top, y_bot = expanded
+        interior = float(vsm[y_top:y_bot, x].mean())
+        smean = float(sat[y_top:y_bot, x].mean())
+        width = float(y_bot - y_top)
+        if interior < 125 or smean > 150 or abs(width - med_w) > 0.5 * max(med_w, 1.0):
+            misses += 1
+            if misses >= 5:
+                break
+            continue
+        misses = 0
+        extra.append((x, y_top, y_bot))
+    if extra:
+        samples = samples + extra
+        xs = np.array([p[0] for p in samples], dtype=np.float32)
+        tops = np.array([p[1] for p in samples], dtype=np.float32)
+        bots = np.array([p[2] for p in samples], dtype=np.float32)
+    return _fit_quad_from_bands(
+        xs, tops, bots, origin, min_span=max(100.0, 0.10 * w_full), val=vsm, sat=sat
+    )
 
 
 def _collect_segments(gray: np.ndarray, min_len: float) -> list[tuple[float, float, np.ndarray]]:

--- a/fretboard_cam/fretboard_cam/overlay.py
+++ b/fretboard_cam/fretboard_cam/overlay.py
@@ -11,7 +11,6 @@ import numpy as np
 from .geometry import (
     NUM_STRINGS,
     canonical_to_image,
-    cell_canonical_center,
     cell_canonical_quad,
     fretboard_homography,
     normalized_fret_xs,
@@ -54,17 +53,6 @@ class OverlayConfig:
     label: str = "DEMO  numbered frets"
 
 
-def _blend_poly(
-    frame: np.ndarray,
-    points: np.ndarray,
-    color: tuple[int, int, int],
-    alpha: float,
-) -> None:
-    overlay = frame.copy()
-    cv2.fillConvexPoly(overlay, np.round(points).astype(np.int32), color)
-    cv2.addWeighted(overlay, alpha, frame, 1.0 - alpha, 0, dst=frame)
-
-
 def _draw_polyline(
     frame: np.ndarray,
     points: np.ndarray,
@@ -73,7 +61,9 @@ def _draw_polyline(
     closed: bool = False,
 ) -> None:
     pts = np.round(points).astype(np.int32)
-    cv2.polylines(frame, [pts], isClosed=closed, color=color, thickness=thickness, lineType=cv2.LINE_AA)
+    cv2.polylines(
+        frame, [pts], isClosed=closed, color=color, thickness=thickness, lineType=cv2.LINE_AA
+    )
 
 
 def draw_fretboard_overlay(
@@ -108,6 +98,7 @@ def draw_fretboard_overlay(
             )
             _draw_polyline(out, line, GRID_COLOR, thickness=1)
 
+    cells: list[tuple[np.ndarray, int]] = []
     for string_number, fret in cfg.highlights:
         if not 1 <= string_number <= cfg.num_strings:
             continue
@@ -119,16 +110,19 @@ def draw_fretboard_overlay(
             ),
             homography,
         )
-        _blend_poly(out, cell, HIGHLIGHT_FILL, cfg.alpha)
-        _draw_polyline(out, cell, HIGHLIGHT_FILL, thickness=1, closed=True)
+        cells.append((cell, fret))
 
-        if cfg.draw_labels:
-            center = canonical_to_image(
-                cell_canonical_center(
-                    string_number, fret, cfg.visible_frets, cfg.num_strings
-                ).reshape(1, 2),
-                homography,
-            )[0]
+    if cells:
+        wash = out.copy()
+        for cell, _fret in cells:
+            cv2.fillConvexPoly(wash, np.round(cell).astype(np.int32), HIGHLIGHT_FILL)
+        cv2.addWeighted(wash, cfg.alpha, out, 1.0 - cfg.alpha, 0, dst=out)
+        for cell, _fret in cells:
+            _draw_polyline(out, cell, HIGHLIGHT_FILL, thickness=1, closed=True)
+
+    if cfg.draw_labels:
+        for cell, fret in cells:
+            center = cell.mean(axis=0)
             radius = max(8, int(round(np.linalg.norm(cell[0] - cell[1]) * 0.18)))
             cx, cy = int(round(center[0])), int(round(center[1]))
             cv2.circle(out, (cx, cy), radius, (30, 30, 30), -1, lineType=cv2.LINE_AA)
@@ -169,8 +163,7 @@ def draw_hud(
     confidence: float | None,
     extra_lines: Iterable[str] = (),
 ) -> np.ndarray:
-    """Draw a small status block in the lower-left, similar in spirit to the demo HUD."""
-    out = frame.copy()
+    """Draw a small status block in the lower-left. Mutates `frame` and returns it."""
     lines = [
         f"detector: {detector}",
         f"lock: {'yes' if tracked else 'lost'}",
@@ -178,10 +171,10 @@ def draw_hud(
     if confidence is not None:
         lines.append(f"conf: {confidence:.2f}")
     lines.extend(extra_lines)
-    x, y0 = 16, out.shape[0] - 18 * (len(lines) + 1)
+    x, y0 = 16, frame.shape[0] - 18 * (len(lines) + 1)
     for i, line in enumerate(lines):
         cv2.putText(
-            out,
+            frame,
             line,
             (x, y0 + i * 18),
             cv2.FONT_HERSHEY_SIMPLEX,
@@ -190,4 +183,4 @@ def draw_hud(
             1,
             cv2.LINE_AA,
         )
-    return out
+    return frame

--- a/fretboard_cam/fretboard_cam/overlay.py
+++ b/fretboard_cam/fretboard_cam/overlay.py
@@ -1,0 +1,193 @@
+"""Draw a perspective-correct fretboard overlay onto a video frame."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+import cv2
+import numpy as np
+
+from .geometry import (
+    NUM_STRINGS,
+    canonical_to_image,
+    cell_canonical_center,
+    cell_canonical_quad,
+    fretboard_homography,
+    normalized_fret_xs,
+)
+
+# Demo pattern: a handful of arbitrary (string, fret) cells. String 1 = high E.
+DEFAULT_HIGHLIGHTS: tuple[tuple[int, int], ...] = (
+    (1, 3),
+    (1, 5),
+    (2, 3),
+    (2, 5),
+    (3, 2),
+    (3, 4),
+    (3, 5),
+    (4, 2),
+    (4, 4),
+    (5, 3),
+    (5, 5),
+    (6, 3),
+    (6, 5),
+    (6, 7),
+)
+
+HIGHLIGHT_FILL = (220, 140, 40)  # BGR, close to the demo's translucent blue-cyan
+GRID_COLOR = (210, 210, 210)
+QUAD_COLOR = (80, 220, 80)
+NUT_COLOR = (40, 200, 255)
+TEXT_COLOR = (255, 255, 255)
+
+
+@dataclass(frozen=True)
+class OverlayConfig:
+    visible_frets: int = 12
+    num_strings: int = NUM_STRINGS
+    highlights: Sequence[tuple[int, int]] = DEFAULT_HIGHLIGHTS
+    alpha: float = 0.42
+    draw_grid: bool = True
+    draw_quad: bool = True
+    draw_labels: bool = True
+    label: str = "DEMO  numbered frets"
+
+
+def _blend_poly(
+    frame: np.ndarray,
+    points: np.ndarray,
+    color: tuple[int, int, int],
+    alpha: float,
+) -> None:
+    overlay = frame.copy()
+    cv2.fillConvexPoly(overlay, np.round(points).astype(np.int32), color)
+    cv2.addWeighted(overlay, alpha, frame, 1.0 - alpha, 0, dst=frame)
+
+
+def _draw_polyline(
+    frame: np.ndarray,
+    points: np.ndarray,
+    color: tuple[int, int, int],
+    thickness: int = 1,
+    closed: bool = False,
+) -> None:
+    pts = np.round(points).astype(np.int32)
+    cv2.polylines(frame, [pts], isClosed=closed, color=color, thickness=thickness, lineType=cv2.LINE_AA)
+
+
+def draw_fretboard_overlay(
+    frame: np.ndarray,
+    image_corners: np.ndarray,
+    config: OverlayConfig | None = None,
+) -> np.ndarray:
+    """Return a copy of `frame` with the fretboard overlay drawn."""
+    cfg = config or OverlayConfig()
+    out = frame.copy()
+    homography = fretboard_homography(image_corners)
+    corners = np.asarray(image_corners, dtype=np.float32).reshape(4, 2)
+
+    if cfg.draw_quad:
+        _draw_polyline(out, corners, QUAD_COLOR, thickness=2, closed=True)
+        nut = np.stack([corners[0], corners[3]])
+        _draw_polyline(out, nut, NUT_COLOR, thickness=3, closed=False)
+
+    if cfg.draw_grid:
+        xs = normalized_fret_xs(cfg.visible_frets)
+        for x in xs:
+            line = canonical_to_image(
+                np.array([[x, 0.0], [x, 1.0]], dtype=np.float32),
+                homography,
+            )
+            _draw_polyline(out, line, GRID_COLOR, thickness=1)
+        for i in range(cfg.num_strings + 1):
+            y = i / cfg.num_strings
+            line = canonical_to_image(
+                np.array([[0.0, y], [1.0, y]], dtype=np.float32),
+                homography,
+            )
+            _draw_polyline(out, line, GRID_COLOR, thickness=1)
+
+    for string_number, fret in cfg.highlights:
+        if not 1 <= string_number <= cfg.num_strings:
+            continue
+        if not 1 <= fret <= cfg.visible_frets:
+            continue
+        cell = canonical_to_image(
+            cell_canonical_quad(
+                string_number, fret, cfg.visible_frets, cfg.num_strings
+            ),
+            homography,
+        )
+        _blend_poly(out, cell, HIGHLIGHT_FILL, cfg.alpha)
+        _draw_polyline(out, cell, HIGHLIGHT_FILL, thickness=1, closed=True)
+
+        if cfg.draw_labels:
+            center = canonical_to_image(
+                cell_canonical_center(
+                    string_number, fret, cfg.visible_frets, cfg.num_strings
+                ).reshape(1, 2),
+                homography,
+            )[0]
+            radius = max(8, int(round(np.linalg.norm(cell[0] - cell[1]) * 0.18)))
+            cx, cy = int(round(center[0])), int(round(center[1]))
+            cv2.circle(out, (cx, cy), radius, (30, 30, 30), -1, lineType=cv2.LINE_AA)
+            cv2.circle(out, (cx, cy), radius, TEXT_COLOR, 1, lineType=cv2.LINE_AA)
+            label = str(fret)
+            font_scale = max(0.35, radius / 18.0)
+            (tw, th), _ = cv2.getTextSize(label, cv2.FONT_HERSHEY_SIMPLEX, font_scale, 1)
+            cv2.putText(
+                out,
+                label,
+                (cx - tw // 2, cy + th // 2),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                font_scale,
+                TEXT_COLOR,
+                1,
+                cv2.LINE_AA,
+            )
+
+    if cfg.label:
+        cv2.putText(
+            out,
+            cfg.label,
+            (16, 32),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.7,
+            (255, 255, 255),
+            2,
+            cv2.LINE_AA,
+        )
+    return out
+
+
+def draw_hud(
+    frame: np.ndarray,
+    *,
+    detector: str,
+    tracked: bool,
+    confidence: float | None,
+    extra_lines: Iterable[str] = (),
+) -> np.ndarray:
+    """Draw a small status block in the lower-left, similar in spirit to the demo HUD."""
+    out = frame.copy()
+    lines = [
+        f"detector: {detector}",
+        f"lock: {'yes' if tracked else 'lost'}",
+    ]
+    if confidence is not None:
+        lines.append(f"conf: {confidence:.2f}")
+    lines.extend(extra_lines)
+    x, y0 = 16, out.shape[0] - 18 * (len(lines) + 1)
+    for i, line in enumerate(lines):
+        cv2.putText(
+            out,
+            line,
+            (x, y0 + i * 18),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.45,
+            (240, 240, 240),
+            1,
+            cv2.LINE_AA,
+        )
+    return out

--- a/fretboard_cam/fretboard_cam/record.py
+++ b/fretboard_cam/fretboard_cam/record.py
@@ -1,0 +1,132 @@
+"""On-screen record control and dual (raw + overlay) capture."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+BUTTON_SIZE = (168, 54)
+BUTTON_MARGIN = 16
+
+
+def recordings_root() -> Path:
+    return Path(__file__).resolve().parent.parent / "recordings"
+
+
+def record_button_rect(frame_w: int, frame_h: int) -> tuple[int, int, int, int]:
+    bw, bh = BUTTON_SIZE
+    x1 = frame_w - bw - BUTTON_MARGIN
+    y1 = BUTTON_MARGIN
+    return x1, y1, x1 + bw, y1 + bh
+
+
+def point_in_rect(x: int, y: int, rect: tuple[int, int, int, int]) -> bool:
+    x1, y1, x2, y2 = rect
+    return x1 <= x <= x2 and y1 <= y <= y2
+
+
+def draw_record_button(frame: np.ndarray, recording: bool) -> tuple[int, int, int, int]:
+    """Draw a clickable REC/STOP button in the top-right. Returns its rect."""
+    h, w = frame.shape[:2]
+    rect = record_button_rect(w, h)
+    x1, y1, x2, y2 = rect
+    fill = (40, 40, 180) if recording else (40, 40, 40)
+    border = (60, 60, 255) if recording else (220, 220, 220)
+    cv2.rectangle(frame, (x1, y1), (x2, y2), fill, -1)
+    cv2.rectangle(frame, (x1, y1), (x2, y2), border, 2)
+    cx, cy = x1 + 28, (y1 + y2) // 2
+    cv2.circle(frame, (cx, cy), 10, (40, 40, 255), -1, lineType=cv2.LINE_AA)
+    if recording:
+        cv2.circle(frame, (cx, cy), 14, (80, 80, 255), 2, lineType=cv2.LINE_AA)
+    label = "STOP" if recording else "REC"
+    cv2.putText(
+        frame,
+        label,
+        (x1 + 48, y1 + 36),
+        cv2.FONT_HERSHEY_SIMPLEX,
+        0.9,
+        (255, 255, 255),
+        2,
+        cv2.LINE_AA,
+    )
+    return rect
+
+
+def make_writer(path: Path, width: int, height: int, fps: float) -> cv2.VideoWriter:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fps = max(float(fps), 8.0)
+    for codec in ("avc1", "mp4v"):
+        writer = cv2.VideoWriter(
+            str(path), cv2.VideoWriter_fourcc(*codec), fps, (width, height)
+        )
+        if writer.isOpened():
+            return writer
+        writer.release()
+    raise RuntimeError(f"could not open video writer: {path}")
+
+
+class SessionRecorder:
+    """Writes paired raw.mp4 + overlay.mp4 into a timestamped folder."""
+
+    def __init__(self, root: Path | None = None):
+        self.root = Path(root) if root is not None else recordings_root()
+        self.active = False
+        self.session_dir: Path | None = None
+        self.raw_writer: cv2.VideoWriter | None = None
+        self.overlay_writer: cv2.VideoWriter | None = None
+        self.frames_written = 0
+
+    def toggle(self, width: int, height: int, fps: float) -> Path | None:
+        if self.active:
+            return self.stop()
+        self.start(width, height, fps)
+        return self.session_dir
+
+    def start(self, width: int, height: int, fps: float) -> Path:
+        stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        session = self.root / stamp
+        session.mkdir(parents=True, exist_ok=True)
+        self.raw_writer = make_writer(session / "raw.mp4", width, height, fps)
+        self.overlay_writer = make_writer(session / "overlay.mp4", width, height, fps)
+        (session / "README.txt").write_text(
+            "Jam Dashboard capture\n"
+            "raw.mp4      camera frames with no overlay\n"
+            "overlay.mp4  the same frames with the fretboard overlay\n"
+            f"size {width}x{height}  fps {fps:.1f}\n",
+            encoding="utf-8",
+        )
+        self.session_dir = session
+        self.active = True
+        self.frames_written = 0
+        print(f"recording → {session}", flush=True)
+        return session
+
+    def write(self, raw: np.ndarray, overlay: np.ndarray) -> None:
+        if not self.active:
+            return
+        if self.raw_writer is not None:
+            self.raw_writer.write(raw)
+        if self.overlay_writer is not None:
+            self.overlay_writer.write(overlay)
+        self.frames_written += 1
+
+    def stop(self) -> Path | None:
+        session = self.session_dir
+        if self.raw_writer is not None:
+            self.raw_writer.release()
+        if self.overlay_writer is not None:
+            self.overlay_writer.release()
+        self.raw_writer = None
+        self.overlay_writer = None
+        self.active = False
+        if session is not None:
+            print(
+                f"saved {self.frames_written} frames to {session} "
+                f"(raw.mp4 + overlay.mp4)",
+                flush=True,
+            )
+        self.session_dir = None
+        return session

--- a/fretboard_cam/fretboard_cam/synthetic.py
+++ b/fretboard_cam/fretboard_cam/synthetic.py
@@ -69,6 +69,76 @@ def make_synthetic_frame(
     return frame, ordered
 
 
+def make_tele_style_frame(
+    width: int = 960,
+    height: int = 540,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Maple neck on the left, high-contrast strings on a dark pickguard to the right.
+
+    The overlay should lock to the neck quad, not the pickguard string bundle.
+    """
+    neck = np.array(
+        [
+            [80.0, 330.0],   # nut bass
+            [520.0, 345.0],  # body bass (end of fretboard)
+            [515.0, 255.0],  # body treble
+            [90.0, 245.0],   # nut treble
+        ],
+        dtype=np.float32,
+    )
+    ordered = order_fretboard_corners(neck)
+    frame = np.full((height, width, 3), (36, 40, 48), dtype=np.uint8)
+    # Butterscotch body behind the pickguard.
+    cv2.ellipse(frame, (720, 300), (210, 160), 0, 0, 360, (60, 145, 190), -1)
+    # Dark pickguard with bright strings — a trap for line-only fitters.
+    pg = np.array(
+        [[500.0, 240.0], [860.0, 250.0], [850.0, 360.0], [505.0, 350.0]],
+        dtype=np.int32,
+    )
+    cv2.fillConvexPoly(frame, pg, (18, 18, 22))
+    maple = (90, 175, 220)
+    cv2.fillConvexPoly(frame, np.round(ordered).astype(np.int32), maple)
+
+    homography = fretboard_homography(ordered)
+    xs = normalized_fret_xs(12)
+    for x in xs:
+        line = canonical_to_image(
+            np.array([[x, 0.04], [x, 0.96]], dtype=np.float32), homography
+        )
+        cv2.line(
+            frame,
+            tuple(np.round(line[0]).astype(int)),
+            tuple(np.round(line[1]).astype(int)),
+            (40, 40, 45),
+            2,
+            cv2.LINE_AA,
+        )
+    for i in range(6):
+        y = (i + 0.5) / 6.0
+        neck_line = canonical_to_image(
+            np.array([[0.0, y], [1.0, y]], dtype=np.float32), homography
+        )
+        cv2.line(
+            frame,
+            tuple(np.round(neck_line[0]).astype(int)),
+            tuple(np.round(neck_line[1]).astype(int)),
+            (30, 30, 30),
+            1,
+            cv2.LINE_AA,
+        )
+        # Continue the same strings across the pickguard at high contrast.
+        x0, y0 = neck_line[1]
+        cv2.line(
+            frame,
+            (int(round(x0)), int(round(y0))),
+            (850, int(round(y0 + 8))),
+            (210, 210, 210),
+            2,
+            cv2.LINE_AA,
+        )
+    return frame, ordered
+
+
 def moving_corners(
     frame_index: int,
     base: np.ndarray | None = None,

--- a/fretboard_cam/fretboard_cam/synthetic.py
+++ b/fretboard_cam/fretboard_cam/synthetic.py
@@ -1,0 +1,89 @@
+"""Helpers for drawing a fake guitar neck used by tests and local demos."""
+
+from __future__ import annotations
+
+import cv2
+import numpy as np
+
+from .geometry import (
+    canonical_to_image,
+    fretboard_homography,
+    normalized_fret_xs,
+    order_fretboard_corners,
+)
+
+
+def make_synthetic_frame(
+    width: int = 960,
+    height: int = 540,
+    corners: np.ndarray | None = None,
+    visible_frets: int = 12,
+    background: tuple[int, int, int] = (30, 30, 30),
+    board_color: tuple[int, int, int] = (70, 160, 210),
+) -> tuple[np.ndarray, np.ndarray]:
+    """Render a trapezoid fretboard with strings and frets.
+
+    Returns (frame, ordered_corners).
+    """
+    if corners is None:
+        corners = np.array(
+            [
+                [120.0, 360.0],  # nut bass
+                [820.0, 390.0],  # body bass
+                [800.0, 230.0],  # body treble
+                [150.0, 250.0],  # nut treble
+            ],
+            dtype=np.float32,
+        )
+    ordered = order_fretboard_corners(corners)
+    frame = np.full((height, width, 3), background, dtype=np.uint8)
+    cv2.fillConvexPoly(frame, np.round(ordered).astype(np.int32), board_color)
+
+    homography = fretboard_homography(ordered)
+    xs = normalized_fret_xs(visible_frets)
+    for x in xs:
+        line = canonical_to_image(
+            np.array([[x, 0.02], [x, 0.98]], dtype=np.float32), homography
+        )
+        cv2.line(
+            frame,
+            tuple(np.round(line[0]).astype(int)),
+            tuple(np.round(line[1]).astype(int)),
+            (40, 40, 40),
+            2,
+            cv2.LINE_AA,
+        )
+    for i in range(6):
+        y = (i + 0.5) / 6.0
+        line = canonical_to_image(
+            np.array([[0.0, y], [1.0, y]], dtype=np.float32), homography
+        )
+        cv2.line(
+            frame,
+            tuple(np.round(line[0]).astype(int)),
+            tuple(np.round(line[1]).astype(int)),
+            (20, 20, 20),
+            1,
+            cv2.LINE_AA,
+        )
+    return frame, ordered
+
+
+def moving_corners(
+    frame_index: int,
+    base: np.ndarray | None = None,
+    dx: float = 1.4,
+    dy: float = 0.4,
+) -> np.ndarray:
+    if base is None:
+        base = np.array(
+            [
+                [120.0, 360.0],
+                [820.0, 390.0],
+                [800.0, 230.0],
+                [150.0, 250.0],
+            ],
+            dtype=np.float32,
+        )
+    offset = np.array([frame_index * dx, frame_index * dy], dtype=np.float32)
+    return order_fretboard_corners(base + offset)

--- a/fretboard_cam/fretboard_cam/track.py
+++ b/fretboard_cam/fretboard_cam/track.py
@@ -1,0 +1,83 @@
+"""Temporal smoothing and optical-flow tracking of fretboard corners."""
+
+from __future__ import annotations
+
+import cv2
+import numpy as np
+
+from .geometry import order_fretboard_corners
+
+
+class QuadTracker:
+    """Keep a stable fretboard quad across frames.
+
+    New detections are blended with the previous quad. Between detections,
+    Lucas-Kanade optical flow carries the four corners forward.
+    """
+
+    def __init__(self, blend: float = 0.35, max_flow_error: float = 25.0):
+        self.blend = blend
+        self.max_flow_error = max_flow_error
+        self.corners: np.ndarray | None = None
+        self.prev_gray: np.ndarray | None = None
+        self.missed = 0
+
+    @property
+    def locked(self) -> bool:
+        return self.corners is not None
+
+    def update(
+        self,
+        frame: np.ndarray,
+        detected_corners: np.ndarray | None,
+    ) -> np.ndarray | None:
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        flowed = self._flow(gray)
+
+        if detected_corners is not None:
+            detected = order_fretboard_corners(detected_corners)
+            if self.corners is None:
+                self.corners = detected
+            else:
+                base = flowed if flowed is not None else self.corners
+                self.corners = order_fretboard_corners(
+                    (1.0 - self.blend) * base + self.blend * detected
+                )
+            self.missed = 0
+        elif flowed is not None:
+            self.corners = flowed
+            self.missed += 1
+        else:
+            self.missed += 1
+            if self.missed > 30:
+                self.corners = None
+
+        self.prev_gray = gray
+        return None if self.corners is None else self.corners.copy()
+
+    def _flow(self, gray: np.ndarray) -> np.ndarray | None:
+        if self.corners is None or self.prev_gray is None:
+            return None
+        prev_pts = self.corners.reshape(-1, 1, 2).astype(np.float32)
+        next_pts, status, err = cv2.calcOpticalFlowPyrLK(
+            self.prev_gray,
+            gray,
+            prev_pts,
+            None,
+            winSize=(21, 21),
+            maxLevel=3,
+            criteria=(cv2.TERM_CRITERIA_EPS | cv2.TERM_CRITERIA_COUNT, 30, 0.01),
+        )
+        if next_pts is None or status is None:
+            return None
+        status = status.reshape(-1)
+        if int(status.sum()) < 4:
+            return None
+        if err is not None and float(np.max(err)) > self.max_flow_error:
+            return None
+        return order_fretboard_corners(next_pts.reshape(4, 2))
+
+    def reset(self) -> None:
+        self.corners = None
+        self.prev_gray = None
+        self.missed = 0

--- a/fretboard_cam/pyproject.toml
+++ b/fretboard_cam/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "fretboard-cam"
+version = "0.1.0"
+description = "Live camera overlay of numbered markers on a guitar fretboard."
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+  "numpy>=1.24",
+  "opencv-python-headless>=4.8",
+]
+
+[project.optional-dependencies]
+ml = ["ultralytics>=8.2.0"]
+dev = ["pytest>=7.0"]
+
+[project.scripts]
+fretboard-cam = "fretboard_cam.app:main"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]

--- a/fretboard_cam/pyproject.toml
+++ b/fretboard_cam/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
   "numpy>=1.24",
-  "opencv-python-headless>=4.8",
+  "opencv-python>=4.8",
 ]
 
 [project.optional-dependencies]

--- a/fretboard_cam/requirements-ml.txt
+++ b/fretboard_cam/requirements-ml.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+ultralytics>=8.2.0

--- a/fretboard_cam/requirements-ml.txt
+++ b/fretboard_cam/requirements-ml.txt
@@ -1,2 +1,3 @@
 -r requirements.txt
 ultralytics>=8.2.0
+clip @ git+https://github.com/ultralytics/CLIP.git

--- a/fretboard_cam/requirements.txt
+++ b/fretboard_cam/requirements.txt
@@ -1,0 +1,3 @@
+numpy>=1.24
+opencv-python-headless>=4.8
+pytest>=7.0

--- a/fretboard_cam/requirements.txt
+++ b/fretboard_cam/requirements.txt
@@ -1,3 +1,3 @@
 numpy>=1.24
-opencv-python-headless>=4.8
+opencv-python>=4.8
 pytest>=7.0

--- a/fretboard_cam/testdata/chase-tele-20260812/README.md
+++ b/fretboard_cam/testdata/chase-tele-20260812/README.md
@@ -1,0 +1,8 @@
+# Test capture — Telecaster, FaceTime camera
+
+Recorded 2026-08-12 on the author's Mac (FaceTime HD, 1280x720, ~24 fps).
+
+- `raw.mp4` — camera only, no overlay. Use this to iterate on detection/alignment.
+- `overlay.mp4` — same frames with the current fretboard overlay (misaligned on the body/pickguard).
+
+The guitar is a natural-finish Tele-style with a maple neck, held roughly horizontal / slightly diagonal. Bright lamp glare on the left of the neck.

--- a/fretboard_cam/testdata/chase-tele-20260812/README.md
+++ b/fretboard_cam/testdata/chase-tele-20260812/README.md
@@ -3,6 +3,7 @@
 Recorded 2026-08-12 on the author's Mac (FaceTime HD, 1280x720, ~24 fps).
 
 - `raw.mp4` — camera only, no overlay. Use this to iterate on detection/alignment.
-- `overlay.mp4` — same frames with the current fretboard overlay (misaligned on the body/pickguard).
+- `overlay.mp4` — original overlay that locked onto the body/pickguard (before the maple-band fitter).
 
-The guitar is a natural-finish Tele-style with a maple neck, held roughly horizontal / slightly diagonal. Bright lamp glare on the left of the neck.
+The guitar is a natural-finish Tele-style with a maple neck, held roughly horizontal / slightly diagonal. Bright lamp glare on the left of the neck. A second guitar in a stand sits in the lower-left background.
+

--- a/fretboard_cam/testdata/chase-tele-20260812/overlay.mp4
+++ b/fretboard_cam/testdata/chase-tele-20260812/overlay.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6675fac5c281b7cfa77f781daacad91eff1d5cf41b28d73e9cad7322a359d909
+size 4560973

--- a/fretboard_cam/testdata/chase-tele-20260812/raw.mp4
+++ b/fretboard_cam/testdata/chase-tele-20260812/raw.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:817b573e6da9ce232831aee1eb1faf056e7c50c817c6cd498e027534dc3e3b5d
+size 3837919

--- a/fretboard_cam/testdata/chase-tele-20260812_2/README.txt
+++ b/fretboard_cam/testdata/chase-tele-20260812_2/README.txt
@@ -1,0 +1,4 @@
+Jam Dashboard capture
+raw.mp4      camera frames with no overlay
+overlay.mp4  the same frames with the fretboard overlay
+size 1280x720  fps 13.6

--- a/fretboard_cam/testdata/chase-tele-20260812_2/overlay.mp4
+++ b/fretboard_cam/testdata/chase-tele-20260812_2/overlay.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d85b1847747567d72c893bfc7709f2841dc1715243f9349bc15bc6c2795582e
+size 1201521

--- a/fretboard_cam/testdata/chase-tele-20260812_2/raw.mp4
+++ b/fretboard_cam/testdata/chase-tele-20260812_2/raw.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c7dac52dfafb291132fb9958080e7c6441f2482501f5cbf8a769ed1b01c93f7
+size 1047733

--- a/fretboard_cam/tests/test_app.py
+++ b/fretboard_cam/tests/test_app.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from fretboard_cam.app import parse_corners, parse_highlights
+
+
+def test_parse_corners():
+    pts = parse_corners("1,2,3,4,5,6,7,8")
+    assert pts.shape == (4, 2)
+    assert pts[0, 0] == 1
+    assert pts[3, 1] == 8
+
+
+def test_parse_highlights():
+    cells = parse_highlights("6:3, 1:5,2:7")
+    assert cells == [(6, 3), (1, 5), (2, 7)]

--- a/fretboard_cam/tests/test_geometry.py
+++ b/fretboard_cam/tests/test_geometry.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from fretboard_cam.geometry import (
+    cell_canonical_center,
+    cell_canonical_quad,
+    fret_distance_from_nut,
+    fretboard_homography,
+    image_to_canonical,
+    normalized_fret_xs,
+    order_fretboard_corners,
+    project_cell,
+    string_center_y,
+)
+
+
+def test_twelfth_fret_is_half_scale():
+    assert fret_distance_from_nut(12) == pytest.approx(0.5)
+
+
+def test_normalized_frets_span_zero_to_one():
+    xs = normalized_fret_xs(12)
+    assert xs[0] == pytest.approx(0.0)
+    assert xs[-1] == pytest.approx(1.0)
+    assert xs[12] == pytest.approx(1.0)
+    assert np.all(np.diff(xs) > 0)
+
+
+def test_lower_frets_are_wider_than_higher_frets():
+    xs = normalized_fret_xs(12)
+    first = xs[1] - xs[0]
+    last = xs[-1] - xs[-2]
+    assert first > last
+
+
+def test_string_centers_run_bass_to_treble():
+    assert string_center_y(6) < string_center_y(1)
+    assert string_center_y(6) == pytest.approx(1 / 12)
+    assert string_center_y(1) == pytest.approx(11 / 12)
+
+
+def test_order_fretboard_corners_with_tapered_neck():
+    shuffled = np.array(
+        [
+            [800.0, 230.0],  # body treble
+            [120.0, 360.0],  # nut bass
+            [150.0, 250.0],  # nut treble
+            [820.0, 390.0],  # body bass
+        ],
+        dtype=np.float32,
+    )
+    ordered = order_fretboard_corners(shuffled)
+    nut_width = np.linalg.norm(ordered[0] - ordered[3])
+    body_width = np.linalg.norm(ordered[1] - ordered[2])
+    assert nut_width < body_width
+    assert ordered[0, 1] > ordered[3, 1]  # bass below treble in image coords
+    assert ordered[0, 0] < ordered[1, 0]  # nut left of body
+
+
+def test_order_fretboard_corners_without_taper_uses_left_as_nut():
+    rectangle = np.array(
+        [
+            [400.0, 100.0],
+            [100.0, 100.0],
+            [400.0, 200.0],
+            [100.0, 200.0],
+        ],
+        dtype=np.float32,
+    )
+    ordered = order_fretboard_corners(rectangle)
+    assert ordered[0, 0] == pytest.approx(100.0)  # nut bass x
+    assert ordered[1, 0] == pytest.approx(400.0)  # body bass x
+
+
+def test_homography_roundtrip():
+    corners = np.array(
+        [
+            [100.0, 300.0],
+            [700.0, 320.0],
+            [680.0, 180.0],
+            [120.0, 200.0],
+        ],
+        dtype=np.float32,
+    )
+    H = fretboard_homography(corners)
+    canonical = np.array([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]], dtype=np.float32)
+    back = image_to_canonical(corners, H)
+    np.testing.assert_allclose(back, canonical, atol=1e-3)
+
+
+def test_cell_center_is_inside_cell_quad():
+    quad = cell_canonical_quad(6, 3, visible_frets=12)
+    center = cell_canonical_center(6, 3, visible_frets=12)
+    xs, ys = quad[:, 0], quad[:, 1]
+    assert xs.min() <= center[0] <= xs.max()
+    assert ys.min() <= center[1] <= ys.max()
+
+
+def test_project_cell_lands_near_nut_for_fret_one_bass():
+    corners = np.array(
+        [
+            [100.0, 300.0],
+            [700.0, 320.0],
+            [680.0, 180.0],
+            [120.0, 200.0],
+        ],
+        dtype=np.float32,
+    )
+    cell = project_cell(6, 1, corners, visible_frets=12)
+    # Fret 1 on the low E should sit against the nut, bass side.
+    assert cell[:, 0].mean() < 250
+    assert cell[:, 1].mean() > 240

--- a/fretboard_cam/tests/test_neck.py
+++ b/fretboard_cam/tests/test_neck.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from fretboard_cam.neck import neck_quad_from_lines, neck_quad_from_mask
+from fretboard_cam.neck import neck_quad_from_lines, neck_quad_from_mask, neck_quad_from_ridge
 from fretboard_cam.synthetic import make_synthetic_frame, make_tele_style_frame
 
 
@@ -55,3 +55,19 @@ def test_line_detector_prefers_maple_neck_over_pickguard_strings():
     for pt in quad:
         nearest = float(np.linalg.norm(pt - corners, axis=1).min())
         assert nearest < 80
+
+
+def test_ridge_detector_prefers_maple_neck_over_pickguard_strings():
+    frame, corners = make_tele_style_frame()
+    box = np.array([40.0, 180.0, 900.0, 420.0], dtype=np.float32)
+    quad = neck_quad_from_ridge(frame, box)
+    assert quad is not None
+    assert float(quad[:, 0].max()) < 620
+    assert float(quad[:, 0].min()) < 220
+    width = float(np.linalg.norm(quad[0] - quad[3]))
+    length = float(np.linalg.norm(quad[0] - quad[1]))
+    assert 20 < width < 140
+    assert length > width * 2.5
+    for pt in quad:
+        nearest = float(np.linalg.norm(pt - corners, axis=1).min())
+        assert nearest < 90

--- a/fretboard_cam/tests/test_neck.py
+++ b/fretboard_cam/tests/test_neck.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 
 from fretboard_cam.neck import neck_quad_from_lines, neck_quad_from_mask
-from fretboard_cam.synthetic import make_synthetic_frame
+from fretboard_cam.synthetic import make_synthetic_frame, make_tele_style_frame
 
 
 def _guitar_mask(width: int = 400, height: int = 240) -> np.ndarray:
@@ -38,3 +38,20 @@ def test_line_detector_finds_synthetic_strings():
     for pt in quad:
         nearest = float(np.linalg.norm(pt - corners, axis=1).min())
         assert nearest < 60
+
+
+def test_line_detector_prefers_maple_neck_over_pickguard_strings():
+    frame, corners = make_tele_style_frame()
+    box = np.array([40.0, 180.0, 900.0, 420.0], dtype=np.float32)
+    quad = neck_quad_from_lines(frame, box)
+    assert quad is not None
+    # Stay on the fretboard, not the dark pickguard to the right of x~520.
+    assert float(quad[:, 0].max()) < 620
+    assert float(quad[:, 0].min()) < 160
+    width = float(np.linalg.norm(quad[0] - quad[3]))
+    length = float(np.linalg.norm(quad[0] - quad[1]))
+    assert 20 < width < 140
+    assert length > width * 2.5
+    for pt in quad:
+        nearest = float(np.linalg.norm(pt - corners, axis=1).min())
+        assert nearest < 80

--- a/fretboard_cam/tests/test_neck.py
+++ b/fretboard_cam/tests/test_neck.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import numpy as np
+
+from fretboard_cam.neck import neck_quad_from_lines, neck_quad_from_mask
+from fretboard_cam.synthetic import make_synthetic_frame
+
+
+def _guitar_mask(width: int = 400, height: int = 240) -> np.ndarray:
+    """Wide body blob on the right, thin neck going left — like a guitar silhouette."""
+    mask = np.zeros((height, width), dtype=np.uint8)
+    # Neck: thin band.
+    mask[100:140, 20:250] = 255
+    # Body: much wider blob.
+    yy, xx = np.ogrid[:height, :width]
+    body = ((xx - 310) ** 2) / (70**2) + ((yy - 120) ** 2) / (90**2) <= 1
+    mask[body] = 255
+    return mask
+
+
+def test_neck_quad_ignores_the_wide_body():
+    mask = _guitar_mask()
+    quad = neck_quad_from_mask(mask)
+    assert quad is not None
+    xs = quad[:, 0]
+    # The extracted quad should live on the thin neck, not the round body.
+    assert xs.max() < 280
+    assert xs.min() < 80
+    height = np.linalg.norm(quad[0] - quad[3])
+    length = np.linalg.norm(quad[0] - quad[1])
+    assert length > height * 2
+
+
+def test_line_detector_finds_synthetic_strings():
+    frame, corners = make_synthetic_frame()
+    quad = neck_quad_from_lines(frame)
+    assert quad is not None
+    for pt in quad:
+        nearest = float(np.linalg.norm(pt - corners, axis=1).min())
+        assert nearest < 60

--- a/fretboard_cam/tests/test_overlay.py
+++ b/fretboard_cam/tests/test_overlay.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import cv2
+import numpy as np
+
+from fretboard_cam.detect import ContourDetector, ManualDetector
+from fretboard_cam.geometry import project_cell
+from fretboard_cam.overlay import OverlayConfig, draw_fretboard_overlay
+from fretboard_cam.synthetic import make_synthetic_frame, moving_corners
+from fretboard_cam.track import QuadTracker
+
+
+def _inside_quad(point: np.ndarray, quad: np.ndarray) -> bool:
+    return (
+        cv2.pointPolygonTest(
+            quad.astype(np.float32),
+            (float(point[0]), float(point[1])),
+            False,
+        )
+        >= 0
+    )
+
+
+def test_overlay_paints_highlighted_cells_inside_the_board():
+    frame, corners = make_synthetic_frame()
+    config = OverlayConfig(
+        visible_frets=12,
+        highlights=((6, 3), (1, 5)),
+        alpha=1.0,
+        draw_grid=False,
+        draw_quad=False,
+        draw_labels=False,
+        label="",
+    )
+    painted = draw_fretboard_overlay(frame, corners, config)
+    delta = cv2.absdiff(frame, painted)
+    assert int(np.count_nonzero(delta)) > 500
+    cell = project_cell(6, 3, corners, visible_frets=12)
+    sample = cell.mean(axis=0).astype(int)
+    assert not np.array_equal(
+        painted[sample[1], sample[0]],
+        frame[sample[1], sample[0]],
+    )
+    assert np.array_equal(painted[20, 20], frame[20, 20])
+
+
+def test_manual_detector_returns_ordered_corners():
+    frame, corners = make_synthetic_frame()
+    shuffled = corners[[2, 0, 3, 1]]
+    detection = ManualDetector(shuffled).detect(frame)
+    assert detection is not None
+    np.testing.assert_allclose(detection.corners, corners, atol=1e-3)
+
+
+def test_contour_detector_finds_synthetic_neck():
+    frame, corners = make_synthetic_frame()
+    detection = ContourDetector().detect(frame)
+    assert detection is not None
+    for pt in detection.corners:
+        nearest = float(np.linalg.norm(pt - corners, axis=1).min())
+        assert _inside_quad(pt, corners) or nearest < 50
+
+
+def test_tracker_follows_a_moving_board():
+    tracker = QuadTracker(blend=1.0)
+    base = None
+    last = None
+    for i in range(12):
+        corners = moving_corners(i, dx=3.0, dy=1.0)
+        frame, ordered = make_synthetic_frame(corners=corners)
+        if i == 0:
+            base = ordered
+        last = tracker.update(frame, ordered if i % 4 == 0 else None)
+        assert last is not None
+    assert last is not None
+    assert base is not None
+    assert last[:, 0].mean() > base[:, 0].mean() + 10
+    assert last[:, 1].mean() > base[:, 1].mean()

--- a/fretboard_cam/tests/test_record.py
+++ b/fretboard_cam/tests/test_record.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import numpy as np
+
+from fretboard_cam.record import (
+    SessionRecorder,
+    point_in_rect,
+    record_button_rect,
+)
+
+
+def test_record_button_is_in_the_top_right():
+    rect = record_button_rect(1280, 720)
+    x1, y1, x2, y2 = rect
+    assert x2 <= 1280
+    assert y1 < 80
+    assert x1 > 1280 / 2
+    assert point_in_rect((x1 + x2) // 2, (y1 + y2) // 2, rect)
+    assert not point_in_rect(10, 10, rect)
+
+
+def test_session_recorder_writes_raw_and_overlay(tmp_path):
+    rec = SessionRecorder(root=tmp_path)
+    session = rec.start(160, 120, 12.0)
+    assert (session / "README.txt").exists()
+    raw = np.zeros((120, 160, 3), dtype=np.uint8)
+    overlay = np.full((120, 160, 3), 40, dtype=np.uint8)
+    for _ in range(6):
+        rec.write(raw, overlay)
+    stopped = rec.stop()
+    assert stopped == session
+    assert not rec.active
+    assert (session / "raw.mp4").exists()
+    assert (session / "overlay.mp4").exists()
+    assert (session / "raw.mp4").stat().st_size > 0
+    assert (session / "overlay.mp4").stat().st_size > 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this is

First slice of the next Jam Dashboard: a **standalone Python app** that finds a guitar neck in a webcam/video and paints numbered fret markers on it. It does **not** reuse the Remix/TypeScript theory code — markers are arbitrary `(string, fret)` cells so we can prove the overlay lock.

Long-term plan (modular dashboard, scale/chord modes, then voice + AI tools) is in `ROADMAP.md`.

## Approach (no custom training)

1. **YOLO-World** prompted for `guitar` / `guitar neck` / `fretboard` — this still boxes the *whole guitar*.
2. **Maple-band quad** inside that box: cluster parallel string/neck-edge lines, score bundles by light-wood interior (so the dark pickguard loses), keep the longest maple run along that band, and use the YOLO box's long axis as an angle prior (so bookshelf edges lose).
3. Fallbacks: GrabCut + thin-region profile, then `--corners`.
4. **Optical-flow tracking** so the overlay does not jump every frame.
5. **Homography overlay** using standard 12-TET fret spacing.

## Live Mac preview

```bash
cd fretboard_cam
source .venv/bin/activate
python -m fretboard_cam --source 0 --detector yolo-world --debug
```

- Preview window at ~24 fps on M2 Max
- **REC / R** writes paired `raw.mp4` + `overlay.mp4` into `recordings/`
- **Q** quits

## Test clip (Git LFS)

`fretboard_cam/testdata/chase-tele-20260812/`

- `raw.mp4` — FaceTime HD, 1280×720, ~24s, maple Tele-style neck, lamp flare on the left
- `overlay.mp4` — original take that locked onto the body/pickguard

Iterate on the raw clip (no webcam needed):

```bash
python -m fretboard_cam \
  --source testdata/chase-tele-20260812/raw.mp4 \
  --detector yolo-world \
  --debug \
  --output /tmp/overlay-retry.mp4
```

**Alignment:** the quad fitter now prefers the maple neck over pickguard strings. Remaining miss: the lamp flare on the left can still pull the band a bit high on some frames; `--corners` remains the escape hatch.

Tests: `python -m pytest -q` in `fretboard_cam/` (20 tests, no model download).

Pull LFS videos after clone: `git lfs pull`.

<!-- CURSOR_AGENT_PR_BODY_END -->